### PR TITLE
Check end-of-lines

### DIFF
--- a/src/Exceptions/SecurityTxtLineNoEolError.php
+++ b/src/Exceptions/SecurityTxtLineNoEolError.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Exceptions;
+
+use Throwable;
+
+class SecurityTxtLineNoEolError extends SecurityTxtError
+{
+
+	public function __construct(string $line, ?Throwable $previous = null)
+	{
+		parent::__construct(
+			"The line (`{$line}`) doesn't end with neither <CRLF> nor <LF>",
+			'draft-foudil-securitytxt-03',
+			$line . '<LF>',
+			"End the line with either <CRLF> or <LF>",
+			'2.2',
+			['4'],
+			previous: $previous,
+		);
+	}
+
+}


### PR DESCRIPTION
"Every line MUST end with either a carriage return and line feed characters (CRLF / %x0D %x0A) or just a line feed character (LF / %x0A)." Which mostly makes sense only as a check for trailing EOL at the end of the file.

https://datatracker.ietf.org/doc/html/rfc9116#name-line-separator