### PR TITLE
Check for possible typos and suggest correct field names

### DIFF
--- a/src/Exceptions/SecurityTxtPossibelFieldTypoWarning.php
+++ b/src/Exceptions/SecurityTxtPossibelFieldTypoWarning.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Exceptions;
+
+use Spaze\SecurityTxt\Fields\SecurityTxtField;
+use Throwable;
+
+class SecurityTxtPossibelFieldTypoWarning extends SecurityTxtWarning
+{
+
+	public function __construct(string $fieldName, SecurityTxtField $suggestion, string $line, ?Throwable $previous = null)
+	{
+		parent::__construct(
+			"Field `{$fieldName}` may be a typo, did you mean `{$suggestion->value}`?",
+			null,
+			str_replace($fieldName, $suggestion->value, $line),
+			"Change `{$fieldName}` to `{$suggestion->value}`",
+			null,
+			previous: $previous,
+		);
+	}
+
+}

--- a/src/Exceptions/SecurityTxtThrowable.php
+++ b/src/Exceptions/SecurityTxtThrowable.php
@@ -10,17 +10,11 @@ abstract class SecurityTxtThrowable extends Exception
 {
 
 	/**
-	 * @param string $message
-	 * @param string $since
-	 * @param string|null $correctValue
-	 * @param string $howToFix
-	 * @param string|null $specSection
 	 * @param list<string> $seeAlsoSections
-	 * @param Throwable|null $previous
 	 */
 	public function __construct(
 		string $message,
-		private readonly string $since,
+		private readonly ?string $since,
 		private readonly ?string $correctValue,
 		private readonly string $howToFix,
 		private readonly ?string $specSection,
@@ -31,7 +25,7 @@ abstract class SecurityTxtThrowable extends Exception
 	}
 
 
-	public function getSince(): string
+	public function getSince(): ?string
 	{
 		return $this->since;
 	}

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -14,6 +14,7 @@ use Spaze\SecurityTxt\Exceptions\SecurityTxtMultipleExpiresError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtMultiplePreferredLanguagesError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtNoContactError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtNoExpiresError;
+use Spaze\SecurityTxt\Exceptions\SecurityTxtPossibelFieldTypoWarning;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtPreferredLanguagesCommonMistakeError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtPreferredLanguagesSeparatorNotCommaError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtThrowable;
@@ -246,6 +247,20 @@ class SecurityTxtParserTest extends TestCase
 		$parseResult = $this->securityTxtParser->parseString("Acknowledgments: {$uri}\n");
 		Assert::count(0, $parseResult->getParseErrors());
 		Assert::same($uri, $parseResult->getSecurityTxt()->getAcknowledgments()[0]->getUri());
+	}
+
+
+	public function testParseStringAcknowledgementsTypo(): void
+	{
+		$uri1 = "https://example.example/whole-of-fame";
+		$uri2 = 'https://example.com/ack.gif';
+		$parseResult = $this->securityTxtParser->parseString("Acknowledgments: {$uri1}\nAcknowledgements: {$uri2}\n");
+		Assert::count(0, $parseResult->getParseErrors());
+		$warning = $parseResult->getParseWarnings()[2][0];
+		Assert::type(SecurityTxtPossibelFieldTypoWarning::class, $warning);
+		Assert::same("Acknowledgments: {$uri2}", $warning->getCorrectValue());
+		Assert::count(1, $parseResult->getSecurityTxt()->getAcknowledgments());
+		Assert::same($uri1, $parseResult->getSecurityTxt()->getAcknowledgments()[0]->getUri());
 	}
 
 }


### PR DESCRIPTION
E.g. "`Acknowledgements` may be a typo, did you mean `Acknowledgments`" as seen in https://www.dropbox.com/.well-known/security.txt (English spelling with an extra "e" after "g" vs American spelling)

Includes an 🐰🥚 because _other_ things can be boring.