### PR TITLE
The violation messages/how-to-fixes are now split to `sprintf`-format and values

### DIFF
--- a/src/Parser/LineProcessors/PreferredLanguagesSetFieldValue.php
+++ b/src/Parser/LineProcessors/PreferredLanguagesSetFieldValue.php
@@ -15,16 +15,16 @@ class PreferredLanguagesSetFieldValue implements LineProcessor
 	public function process(string $value, SecurityTxt $securityTxt): void
 	{
 		$regexp = '/\s*([,.;:])\s*/';
-		$separators = preg_match_all($regexp, $value, $matches, flags: PREG_OFFSET_CAPTURE);
+		$separators = preg_match_all($regexp, $value, $matches);
 		$languages = @preg_split($regexp, $value); // intentionally @, converted to exception
 		if (!$languages) {
 			throw new LogicException('This should not happen');
 		}
 		if ($separators) {
 			$wrongSeparators = [];
-			foreach ($matches[1] as $match) {
-				if ($match[0] !== ',') {
-					$wrongSeparators[$match[0]][] = $match[1];
+			foreach ($matches[1] as $key => $separator) {
+				if ($separator !== ',') {
+					$wrongSeparators[$key + 1] = $separator;
 				}
 			}
 			if ($wrongSeparators) {

--- a/src/SecurityTxt.php
+++ b/src/SecurityTxt.php
@@ -15,7 +15,7 @@ use Spaze\SecurityTxt\Fields\Policy;
 use Spaze\SecurityTxt\Fields\PreferredLanguages;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignatureVerifyResult;
 use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotHttps;
-use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotUriSyntax;
+use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtCanonicalNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtCanonicalNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtContactNotHttps;
@@ -216,7 +216,7 @@ class SecurityTxt
 				$this->acknowledgments[] = $acknowledgments;
 			},
 			function () use ($acknowledgments): void {
-				$this->checkUri($acknowledgments->getUri(), SecurityTxtAcknowledgmentsNotUriSyntax::class, SecurityTxtAcknowledgmentsNotHttps::class);
+				$this->checkUri($acknowledgments->getUri(), SecurityTxtAcknowledgmentsNotUri::class, SecurityTxtAcknowledgmentsNotHttps::class);
 			},
 		);
 	}

--- a/src/Violations/SecurityTxtAcknowledgmentsNotUri.php
+++ b/src/Violations/SecurityTxtAcknowledgmentsNotUri.php
@@ -5,7 +5,7 @@ namespace Spaze\SecurityTxt\Violations;
 
 use Spaze\SecurityTxt\Fields\SecurityTxtField;
 
-class SecurityTxtAcknowledgmentsNotUriSyntax extends SecurityTxtFieldNotUri
+class SecurityTxtAcknowledgmentsNotUri extends SecurityTxtFieldNotUri
 {
 
 	public function __construct(string $uri)

--- a/src/Violations/SecurityTxtContentTypeInvalid.php
+++ b/src/Violations/SecurityTxtContentTypeInvalid.php
@@ -8,11 +8,16 @@ class SecurityTxtContentTypeInvalid extends SecurityTxtSpecViolation
 
 	public function __construct(string $url, ?string $contentType)
 	{
+		$format = $contentType
+			? 'The file at `%s` has a `Content-Type` of `%s` but it should be a `Content-Type` of `text/plain` with the `charset` parameter set to `utf-8`'
+			: 'The file at `%s` has no `Content-Type` but it should be a `Content-Type` of `text/plain` with the `charset` parameter set to `utf-8`';
 		parent::__construct(
-			"The file at `{$url}` has " . ($contentType ? "a `Content-Type` of `{$contentType}`" : 'no `Content-Type`') . " but it should be a `Content-Type` of `text/plain` with the `charset` parameter set to `utf-8`",
+			$format,
+			[$url, (string)$contentType],
 			'draft-foudil-securitytxt-03',
 			'text/plain; charset=utf-8',
 			'Send a correct `Content-Type` header value of `text/plain` with the `charset` parameter set to `utf-8`',
+			[],
 			'3',
 		);
 	}

--- a/src/Violations/SecurityTxtContentTypeWrongCharset.php
+++ b/src/Violations/SecurityTxtContentTypeWrongCharset.php
@@ -8,11 +8,16 @@ class SecurityTxtContentTypeWrongCharset extends SecurityTxtSpecViolation
 
 	public function __construct(string $url, string $contentType, ?string $charset)
 	{
+		$format = $charset
+			? 'The file at `%s` has a correct `Content-Type` of `%s` but the `%s` parameter should be changed to `charset=utf-8`'
+			: 'The file at `%s` has a correct `Content-Type` of `%s` but the `charset=utf-8` parameter is missing';
 		parent::__construct(
-			"The file at `{$url}` has a correct `Content-Type` of `{$contentType}` but the " . ($charset ? " `{$charset}` parameter should be changed to `charset=utf-8`" : '`charset=utf-8` parameter is missing'),
+			$format,
+			[$url, $contentType, (string)$charset],
 			'draft-foudil-securitytxt-03',
 			'text/plain; charset=utf-8',
 			$charset ? 'Change the parameter to `charset=utf-8`' : 'Add a `charset=utf-8` parameter',
+			[],
 			'3',
 		);
 	}

--- a/src/Violations/SecurityTxtExpired.php
+++ b/src/Violations/SecurityTxtExpired.php
@@ -12,9 +12,11 @@ class SecurityTxtExpired extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The file is considered stale and should not be used',
+			[],
 			'draft-foudil-securitytxt-09',
 			(new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339),
 			'The `Expires` field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
+			[],
 			'2.5.5',
 			['5.3'],
 		);

--- a/src/Violations/SecurityTxtExpiresOldFormat.php
+++ b/src/Violations/SecurityTxtExpiresOldFormat.php
@@ -12,10 +12,12 @@ class SecurityTxtExpiresOldFormat extends SecurityTxtSpecViolation
 	{
 		$correctValue = $this->expires->format(DATE_RFC3339);
 		parent::__construct(
-			"The value of the `Expires` field follows the format defined in section 3.3 of RFC 5322 but it should be formatted according to the Internet profile of ISO 8601 as defined in RFC 3339 (`{$correctValue}`)",
+			"The value of the `Expires` field follows the format defined in section 3.3 of RFC 5322 but it should be formatted according to the Internet profile of ISO 8601 as defined in RFC 3339",
+			[],
 			'draft-foudil-securitytxt-12',
 			$correctValue,
-			"Change the value of the `Expires` field to `{$correctValue}`",
+			'Change the value of the `Expires` field to `%s`',
+			[$correctValue],
 			'2.5.5',
 		);
 	}

--- a/src/Violations/SecurityTxtExpiresTooLong.php
+++ b/src/Violations/SecurityTxtExpiresTooLong.php
@@ -13,9 +13,11 @@ class SecurityTxtExpiresTooLong extends SecurityTxtSpecViolation
 		$correctValue = (new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339);
 		parent::__construct(
 			'The value of the `Expires` should be less than a year into the future to avoid staleness',
+			[],
 			'draft-foudil-securitytxt-10',
 			$correctValue,
 			'Change the value of the `Expires` field to less than a year into the future',
+			[],
 			'2.5.5',
 		);
 	}

--- a/src/Violations/SecurityTxtExpiresWrongFormat.php
+++ b/src/Violations/SecurityTxtExpiresWrongFormat.php
@@ -11,15 +11,14 @@ class SecurityTxtExpiresWrongFormat extends SecurityTxtSpecViolation
 
 	public function __construct(?DateTimeInterface $expires = null)
 	{
-		if ($expires) {
-			$correctValue = $expires->format(DATE_RFC3339);
-			$howToFix = "Change the value of the `Expires` field to `$correctValue`";
-		}
+		$correctValue = $expires ? $expires->format(DATE_RFC3339) : (new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339);
 		parent::__construct(
 			'The format of the value of the `Expires` field is wrong',
+			[],
 			'draft-foudil-securitytxt-09',
-			$correctValue ?? (new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339),
-			$howToFix ?? 'The `Expires` field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
+			$correctValue,
+			'The `Expires` field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
+			[],
 			'2.5.5',
 		);
 	}

--- a/src/Violations/SecurityTxtFieldNotUri.php
+++ b/src/Violations/SecurityTxtFieldNotUri.php
@@ -17,10 +17,12 @@ abstract class SecurityTxtFieldNotUri extends SecurityTxtSpecViolation
 		?string $specSection,
 	) {
 		parent::__construct(
-			"The `{$field->value}` value (`{$uri}`) doesn't follow the URI syntax described in RFC 3986, the scheme is missing",
+			"The `%s` value (`%s`) doesn't follow the URI syntax described in RFC 3986, the scheme is missing",
+			[$field->value, $uri],
 			$since,
 			$correctValue,
 			$howToFix ?? 'Use a URI as the value',
+			[],
 			$specSection,
 		);
 	}

--- a/src/Violations/SecurityTxtFieldUriNotHttps.php
+++ b/src/Violations/SecurityTxtFieldUriNotHttps.php
@@ -11,10 +11,12 @@ abstract class SecurityTxtFieldUriNotHttps extends SecurityTxtSpecViolation
 	public function __construct(SecurityTxtField $field, string $uri, string $specSection)
 	{
 		parent::__construct(
-			sprintf('If the `%s` field indicates a web URI, then it must begin with "https://"', $field->value),
+			'If the `%s` field indicates a web URI, then it must begin with "https://"',
+			[$field->value],
 			'draft-foudil-securitytxt-06',
 			preg_replace('~^http://~', 'https://', $uri),
-			sprintf('Make sure the `%s` field points to an https:// URI', $field->value),
+			'Make sure the `%s` field points to an https:// URI',
+			[$field->value],
 			$specSection,
 		);
 	}

--- a/src/Violations/SecurityTxtLineNoEol.php
+++ b/src/Violations/SecurityTxtLineNoEol.php
@@ -9,10 +9,12 @@ class SecurityTxtLineNoEol extends SecurityTxtSpecViolation
 	public function __construct(string $line)
 	{
 		parent::__construct(
-			"The line (`{$line}`) doesn't end with neither <CRLF> nor <LF>",
+			"The line (`%s`) doesn't end with neither <CRLF> nor <LF>",
+			[$line],
 			'draft-foudil-securitytxt-03',
 			$line . '<LF>',
 			"End the line with either <CRLF> or <LF>",
+			[],
 			'2.2',
 			['4'],
 		);

--- a/src/Violations/SecurityTxtMultipleExpires.php
+++ b/src/Violations/SecurityTxtMultipleExpires.php
@@ -10,9 +10,11 @@ class SecurityTxtMultipleExpires extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The `Expires` field must not appear more than once',
+			[],
 			'draft-foudil-securitytxt-09',
 			null,
 			'Make sure the `Expires` field is present only once in the file',
+			[],
 			'2.5.5',
 		);
 	}

--- a/src/Violations/SecurityTxtMultiplePreferredLanguages.php
+++ b/src/Violations/SecurityTxtMultiplePreferredLanguages.php
@@ -10,9 +10,11 @@ class SecurityTxtMultiplePreferredLanguages extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The `Preferred-Languages` field must not appear more than once',
+			[],
 			'draft-foudil-securitytxt-05',
 			null,
 			'Make sure the `Preferred-Languages` field is present only once in the file',
+			[],
 			'2.5.8',
 		);
 	}

--- a/src/Violations/SecurityTxtNoContact.php
+++ b/src/Violations/SecurityTxtNoContact.php
@@ -10,9 +10,11 @@ class SecurityTxtNoContact extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The `Contact` field must always be present',
+			[],
 			'draft-foudil-securitytxt-00',
 			null,
 			'Add at least one `Contact` field with a value that follows the URI syntax described in RFC 3986. This means that "mailto" and "tel" URI schemes must be used when specifying email addresses and telephone numbers, e.g. mailto:security@example.com',
+			[],
 			'2.5.3',
 			['2.5.4'],
 		);

--- a/src/Violations/SecurityTxtNoExpires.php
+++ b/src/Violations/SecurityTxtNoExpires.php
@@ -12,9 +12,11 @@ class SecurityTxtNoExpires extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The `Expires` field must always be present',
+			[],
 			'draft-foudil-securitytxt-10',
 			(new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339),
 			'Add an `Expires` field with a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
+			[],
 			'2.5.5',
 		);
 	}

--- a/src/Violations/SecurityTxtPossibelFieldTypo.php
+++ b/src/Violations/SecurityTxtPossibelFieldTypo.php
@@ -11,10 +11,12 @@ class SecurityTxtPossibelFieldTypo extends SecurityTxtSpecViolation
 	public function __construct(string $fieldName, SecurityTxtField $suggestion, string $line)
 	{
 		parent::__construct(
-			"Field `{$fieldName}` may be a typo, did you mean `{$suggestion->value}`?",
+			'Field `%s` may be a typo, did you mean `%s`?',
+			[$fieldName, $suggestion->value],
 			null,
 			str_replace($fieldName, $suggestion->value, $line),
-			"Change `{$fieldName}` to `{$suggestion->value}`",
+			"Change `%s` to `%s`",
+			[$fieldName, $suggestion->value],
 			null,
 		);
 	}

--- a/src/Violations/SecurityTxtPreferredLanguagesCommonMistake.php
+++ b/src/Violations/SecurityTxtPreferredLanguagesCommonMistake.php
@@ -9,10 +9,12 @@ class SecurityTxtPreferredLanguagesCommonMistake extends SecurityTxtSpecViolatio
 	public function __construct(int $position, string $mistake, ?string $correctValue, string $reason)
 	{
 		parent::__construct(
-			"The language tag #{$position} `{$mistake}` in the `Preferred-Languages` field is not correct, {$reason}",
+			'The language tag #%s `%s` in the `Preferred-Languages` field is not correct, %s',
+			[(string)$position, $mistake, $reason],
 			'draft-foudil-securitytxt-05',
 			$correctValue,
 			'Use language tags as defined in RFC 5646, which usually means the shortest ISO 639 code',
+			[],
 			'2.5.8',
 		);
 	}

--- a/src/Violations/SecurityTxtPreferredLanguagesEmpty.php
+++ b/src/Violations/SecurityTxtPreferredLanguagesEmpty.php
@@ -10,9 +10,11 @@ class SecurityTxtPreferredLanguagesEmpty extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The `Preferred-Languages` field must have at least one language listed',
+			[],
 			'draft-foudil-securitytxt-05',
 			null,
 			'Add one or more languages to the field, separated by commas',
+			[],
 			'2.5.8',
 		);
 	}

--- a/src/Violations/SecurityTxtPreferredLanguagesSeparatorNotComma.php
+++ b/src/Violations/SecurityTxtPreferredLanguagesSeparatorNotComma.php
@@ -7,31 +7,25 @@ class SecurityTxtPreferredLanguagesSeparatorNotComma extends SecurityTxtSpecViol
 {
 
 	/**
-	 * @param array<string, list<int>> $wrongSeparators
+	 * @param array<int, string> $wrongSeparators
 	 * @param list<string> $languages
 	 */
 	public function __construct(array $wrongSeparators, array $languages)
 	{
-		$count = count($wrongSeparators);
 		$separators = [];
-		foreach ($wrongSeparators as $separator => $positions) {
-			$separators[] = sprintf(
-				'`%s` at %s %s characters from the start',
-				$separator,
-				count($positions) > 1 ? 'positions' : 'position',
-				implode(', ', $positions),
-			);
+		foreach ($wrongSeparators as $number => $separator) {
+			$separators[] = "#{$number} `{$separator}`";
 		}
-		$message = sprintf(
-			'The `Preferred-Languages` field %s (%s), separate multiple values with a comma (`,`)',
-			$count > 1 ? 'uses wrong separators' : 'uses a wrong separator',
-			implode('; ', $separators),
-		);
+		$message = count($wrongSeparators) > 1
+			? 'The `Preferred-Languages` field uses wrong separators (%s), separate multiple values with a comma (`,`)'
+			: 'The `Preferred-Languages` field uses a wrong separator (%s), separate multiple values with a comma (`,`)';
 		parent::__construct(
 			$message,
+			[implode(', ', $separators)],
 			'draft-foudil-securitytxt-05',
 			implode(', ', $languages),
 			'Use comma (`,`) to list multiple languages in the `Preferred-Languages` field',
+			[],
 			'2.5.8',
 		);
 	}

--- a/src/Violations/SecurityTxtPreferredLanguagesWrongLanguageTags.php
+++ b/src/Violations/SecurityTxtPreferredLanguagesWrongLanguageTags.php
@@ -15,13 +15,16 @@ class SecurityTxtPreferredLanguagesWrongLanguageTags extends SecurityTxtSpecViol
 		foreach ($wrongLanguages as $key => $value) {
 			$tags[] = "#{$key} `{$value}`";
 		}
-		$format = count($wrongLanguages) > 1 ? 'The language tags %s seem invalid' : 'The language tag %s seems invalid';
-		$message = sprintf($format, implode(', ', $tags));
+		$format = count($wrongLanguages) > 1
+			? 'The language tags %s seem invalid, the `Preferred-Languages` field must contain one or more language tags as defined in RFC 5646'
+			: 'The language tag %s seems invalid, the `Preferred-Languages` field must contain one or more language tags as defined in RFC 5646';
 		parent::__construct(
-			$message . ', the `Preferred-Languages` field must contain one or more language tags as defined in RFC 5646',
+			$format,
+			[implode(', ', $tags)],
 			'draft-foudil-securitytxt-05',
 			null,
 			'Use language tags as defined in RFC 5646, which usually means the shortest ISO 639 code like for example `en`',
+			[],
 			'2.5.8',
 		);
 	}

--- a/src/Violations/SecurityTxtSchemeNotHttps.php
+++ b/src/Violations/SecurityTxtSchemeNotHttps.php
@@ -9,10 +9,12 @@ class SecurityTxtSchemeNotHttps extends SecurityTxtSpecViolation
 	public function __construct(string $url)
 	{
 		parent::__construct(
-			"The file at `{$url}` must use HTTPS",
+			"The file at `%s` must use HTTPS",
+			[$url],
 			'draft-foudil-securitytxt-06',
 			preg_replace('~^http://~', 'https://', $url),
 			'Use HTTPS to serve the `security.txt` file',
+			[],
 			'3',
 		);
 	}

--- a/src/Violations/SecurityTxtSignatureExtensionNotLoaded.php
+++ b/src/Violations/SecurityTxtSignatureExtensionNotLoaded.php
@@ -10,9 +10,11 @@ class SecurityTxtSignatureExtensionNotLoaded extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The `gnupg` extension is not available, cannot verify or create signatures',
+			[],
 			'draft-foudil-securitytxt-01',
 			null,
 			'Load the `gnupg` extension',
+			[],
 			'2.3',
 		);
 	}

--- a/src/Violations/SecurityTxtSignatureInvalid.php
+++ b/src/Violations/SecurityTxtSignatureInvalid.php
@@ -10,9 +10,11 @@ class SecurityTxtSignatureInvalid extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'The file is digitally signed using an OpenPGP cleartext signature but the signature is not valid',
+			[],
 			'draft-foudil-securitytxt-01',
 			null,
 			'Sign the file again',
+			[],
 			'2.3',
 		);
 	}

--- a/src/Violations/SecurityTxtSignedButNoCanonical.php
+++ b/src/Violations/SecurityTxtSignedButNoCanonical.php
@@ -10,9 +10,11 @@ class SecurityTxtSignedButNoCanonical extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			'When digital signatures are used, it is also recommended that organizations use the `Canonical` field',
+			[],
 			'draft-foudil-securitytxt-05',
 			null,
 			'Add `Canonical` field pointing where the `security.txt` file is located',
+			[],
 			'2.3',
 			['2.5.2'],
 		);

--- a/src/Violations/SecurityTxtSpecViolation.php
+++ b/src/Violations/SecurityTxtSpecViolation.php
@@ -7,13 +7,17 @@ abstract class SecurityTxtSpecViolation
 {
 
 	/**
+	 * @param list<string> $messageValues
+	 * @param list<string> $howToFixValues
 	 * @param list<string> $seeAlsoSections
 	 */
 	public function __construct(
-		private readonly string $message,
+		private readonly string $messageFormat,
+		private readonly array $messageValues,
 		private readonly ?string $since,
 		private readonly ?string $correctValue,
-		private readonly string $howToFix,
+		private readonly string $howToFixFormat,
+		private readonly array $howToFixValues,
 		private readonly ?string $specSection,
 		private readonly array $seeAlsoSections = [],
 	) {
@@ -22,7 +26,22 @@ abstract class SecurityTxtSpecViolation
 
 	public function getMessage(): string
 	{
-		return $this->message;
+		return vsprintf($this->messageFormat, $this->messageValues);
+	}
+
+
+	public function getMessageFormat(): string
+	{
+		return $this->messageFormat;
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	public function getMessageValues(): array
+	{
+		return $this->messageValues;
 	}
 
 
@@ -40,7 +59,22 @@ abstract class SecurityTxtSpecViolation
 
 	public function getHowToFix(): string
 	{
-		return $this->howToFix;
+		return vsprintf($this->howToFixFormat, $this->howToFixValues);
+	}
+
+
+	public function getHowToFixFormat(): string
+	{
+		return $this->howToFixFormat;
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	public function getHowToFixValues(): array
+	{
+		return $this->howToFixValues;
 	}
 
 

--- a/src/Violations/SecurityTxtTopLevelDiffers.php
+++ b/src/Violations/SecurityTxtTopLevelDiffers.php
@@ -12,9 +12,11 @@ class SecurityTxtTopLevelDiffers extends SecurityTxtSpecViolation
 	) {
 		parent::__construct(
 			'The file at the top-level path is different than the one in the `/.well-known/` path',
+			[],
 			'draft-foudil-securitytxt-09',
 			null,
 			'Redirect the top-level file to the one under the `/.well-known/` path',
+			[],
 			'3',
 		);
 	}

--- a/src/Violations/SecurityTxtTopLevelPathOnly.php
+++ b/src/Violations/SecurityTxtTopLevelPathOnly.php
@@ -10,9 +10,11 @@ class SecurityTxtTopLevelPathOnly extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			"`security.txt` wasn't found under the `/.well-known/` path",
+			[],
 			'draft-foudil-securitytxt-02',
 			null,
 			'Move the `security.txt` file from the top-level location under the `/.well-known/` path and redirect `/security.txt` to `/.well-known/security.txt`',
+			[],
 			'3',
 		);
 	}

--- a/src/Violations/SecurityTxtWellKnownPathOnly.php
+++ b/src/Violations/SecurityTxtWellKnownPathOnly.php
@@ -10,9 +10,11 @@ class SecurityTxtWellKnownPathOnly extends SecurityTxtSpecViolation
 	{
 		parent::__construct(
 			"`security.txt` not found at the top-level path",
+			[],
 			'draft-foudil-securitytxt-02',
 			null,
 			'Redirect the top-level file to the one under the `/.well-known/` path',
+			[],
 			'3',
 		);
 	}

--- a/tests/Parser/LineProcessors/AcknowledgmentsAddFieldValueTest.phpt
+++ b/tests/Parser/LineProcessors/AcknowledgmentsAddFieldValueTest.phpt
@@ -8,7 +8,7 @@ use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
 use Spaze\SecurityTxt\Fields\Acknowledgments;
 use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotHttps;
-use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotUriSyntax;
+use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotUri;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -40,7 +40,7 @@ class AcknowledgmentsAddFieldValueTest extends TestCase
 		$e = Assert::throws(function () use ($processor, $securityTxt): void {
 			$processor->process('no.scheme', $securityTxt);
 		}, SecurityTxtError::class);
-		Assert::type(SecurityTxtAcknowledgmentsNotUriSyntax::class, $e->getViolation());
+		Assert::type(SecurityTxtAcknowledgmentsNotUri::class, $e->getViolation());
 	}
 
 }

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -215,11 +215,11 @@ class SecurityTxtParserTest extends TestCase
 
 	public function testParseStringPreferredLanguagesBadSeparator(): void
 	{
-		$parseResult = $this->securityTxtParser->parseString("Preferred-Languages: en, cs;fi; nl\n");
+		$parseResult = $this->securityTxtParser->parseString("Preferred-Languages: en, cs;fi. nl\n");
 		$error = $parseResult->getParseErrors()[1][0];
 		Assert::count(1, $parseResult->getParseErrors());
 		Assert::type(SecurityTxtPreferredLanguagesSeparatorNotComma::class, $error);
-		Assert::same('The `Preferred-Languages` field uses a wrong separator (`;` at positions 6, 9 characters from the start), separate multiple values with a comma (`,`)', $error->getMessage());
+		Assert::same('The `Preferred-Languages` field uses wrong separators (#2 `;`, #3 `.`), separate multiple values with a comma (`,`)', $error->getMessage());
 		Assert::same('en, cs, fi, nl', $error->getCorrectValue());
 	}
 


### PR DESCRIPTION
Maybe this will make them better translatable or something, or maybe it's just overengineered.