### PR TITLE
PHP 8.4 features part I.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,9 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.1"
-          - "8.2"
-          - "8.3"
           - "8.4"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 		"nette/tester": "^2.5",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
-		"phpstan/phpstan": "^1.10",
+		"phpstan/phpstan": "^2.1",
 		"spaze/coding-standard": "^1.6",
-		"spaze/phpstan-disallowed-calls": "^3.1"
+		"spaze/phpstan-disallowed-calls": "^4.5"
 	},
 	"suggest": {
 		"ext-gnupg": "Needed to verify and create signatures"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		}
 	],
 	"require-dev": {
-		"php": "^8.1",
+		"php": "^8.4",
 		"nette/tester": "^2.5",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3",

--- a/src/Check/SecurityTxtCheckHost.php
+++ b/src/Check/SecurityTxtCheckHost.php
@@ -7,6 +7,8 @@ use DateTimeImmutable;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotOpenUrlException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotParseHostnameException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotReadUrlException;
+use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtHostIpAddressInvalidTypeException;
+use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtHostIpAddressNotFoundException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtHostNotFoundException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtNoHttpCodeException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtNoLocationHeaderException;
@@ -16,6 +18,7 @@ use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtTooManyRedirectsException;
 use Spaze\SecurityTxt\Fetcher\SecurityTxtFetcher;
 use Spaze\SecurityTxt\Parser\SecurityTxtParser;
 use Spaze\SecurityTxt\Parser\SecurityTxtUrlParser;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtCannotVerifySignatureException;
 use Spaze\SecurityTxt\Violations\SecurityTxtSpecViolation;
 
 class SecurityTxtCheckHost
@@ -86,6 +89,9 @@ class SecurityTxtCheckHost
 	 * @throws SecurityTxtNoHttpCodeException
 	 * @throws SecurityTxtNoLocationHeaderException
 	 * @throws SecurityTxtOnlyIpv6HostButIpv6DisabledException
+	 * @throws SecurityTxtHostIpAddressInvalidTypeException
+	 * @throws SecurityTxtHostIpAddressNotFoundException
+	 * @throws SecurityTxtCannotVerifySignatureException
 	 */
 	public function check(string $url, ?int $expiresWarningThreshold = null, bool $strictMode = false, bool $noIpv6 = false): SecurityTxtCheckHostResult
 	{

--- a/src/Check/SecurityTxtCheckHostCli.php
+++ b/src/Check/SecurityTxtCheckHostCli.php
@@ -6,12 +6,12 @@ namespace Spaze\SecurityTxt\Check;
 use DateTimeImmutable;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtFetcherException;
 
-class SecurityTxtCheckHostCli
+readonly class SecurityTxtCheckHostCli
 {
 
 	public function __construct(
-		private readonly ConsolePrinter $consolePrinter,
-		private readonly SecurityTxtCheckHost $checkHost,
+		private ConsolePrinter $consolePrinter,
+		private SecurityTxtCheckHost $checkHost,
 	) {
 	}
 

--- a/src/Check/SecurityTxtCheckHostCli.php
+++ b/src/Check/SecurityTxtCheckHostCli.php
@@ -5,6 +5,7 @@ namespace Spaze\SecurityTxt\Check;
 
 use DateTimeImmutable;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtFetcherException;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtCannotVerifySignatureException;
 
 readonly class SecurityTxtCheckHostCli
 {
@@ -121,7 +122,7 @@ readonly class SecurityTxtCheckHostCli
 			} else {
 				$this->exit(CheckExitStatus::Ok);
 			}
-		} catch (SecurityTxtFetcherException $e) {
+		} catch (SecurityTxtFetcherException | SecurityTxtCannotVerifySignatureException $e) {
 			$this->consolePrinter->error($e->getMessage());
 			$this->exit(CheckExitStatus::FileError);
 		}

--- a/src/Check/SecurityTxtCheckHostResult.php
+++ b/src/Check/SecurityTxtCheckHostResult.php
@@ -8,7 +8,7 @@ use Spaze\SecurityTxt\Fetcher\SecurityTxtFetchResult;
 use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\Violations\SecurityTxtSpecViolation;
 
-class SecurityTxtCheckHostResult implements JsonSerializable
+readonly class SecurityTxtCheckHostResult implements JsonSerializable
 {
 
 	/**
@@ -21,25 +21,25 @@ class SecurityTxtCheckHostResult implements JsonSerializable
 	 * @param list<SecurityTxtSpecViolation> $fileWarnings
 	 */
 	public function __construct(
-		private readonly string $host,
-		private readonly ?array $redirects,
-		private readonly ?string $constructedUrl,
-		private readonly ?string $finalUrl,
-		private readonly ?string $contents,
-		private readonly ?SecurityTxtFetchResult $fetchResult,
-		private readonly array $fetchErrors,
-		private readonly array $fetchWarnings,
-		private readonly array $lineErrors,
-		private readonly array $lineWarnings,
-		private readonly array $fileErrors,
-		private readonly array $fileWarnings,
-		private readonly SecurityTxt $securityTxt,
-		private readonly bool $expiresSoon,
-		private readonly ?bool $isExpired,
-		private readonly ?int $expiryDays,
-		private readonly bool $isValid,
-		private readonly bool $strictMode,
-		private readonly ?int $expiresWarningThreshold,
+		private string $host,
+		private ?array $redirects,
+		private ?string $constructedUrl,
+		private ?string $finalUrl,
+		private ?string $contents,
+		private ?SecurityTxtFetchResult $fetchResult,
+		private array $fetchErrors,
+		private array $fetchWarnings,
+		private array $lineErrors,
+		private array $lineWarnings,
+		private array $fileErrors,
+		private array $fileWarnings,
+		private SecurityTxt $securityTxt,
+		private bool $expiresSoon,
+		private ?bool $isExpired,
+		private ?int $expiryDays,
+		private bool $isValid,
+		private bool $strictMode,
+		private ?int $expiresWarningThreshold,
 	) {
 	}
 

--- a/src/Check/SecurityTxtCheckHostResultFactory.php
+++ b/src/Check/SecurityTxtCheckHostResultFactory.php
@@ -76,6 +76,9 @@ readonly class SecurityTxtCheckHostResultFactory
 		if ($values['contents'] !== null && !is_string($values['contents'])) {
 			throw new SecurityTxtCannotParseJsonException('contents is not a string');
 		}
+		if (!is_array($values['fetchResult'])) {
+			throw new SecurityTxtCannotParseJsonException('fetchResult is not an array');
+		}
 		if (!is_array($values['fetchErrors'])) {
 			throw new SecurityTxtCannotParseJsonException('fetchErrors is not an array');
 		}
@@ -95,6 +98,9 @@ readonly class SecurityTxtCheckHostResultFactory
 			}
 			$lineErrors[$line] = $this->securityTxtJson->createViolationsFromJsonValues(array_values($violations));
 		}
+		if (!is_array($values['lineWarnings'])) {
+			throw new SecurityTxtCannotParseJsonException('lineWarnings is not an array');
+		}
 		$lineWarnings = [];
 		foreach ($values['lineWarnings'] as $line => $violations) {
 			if (!is_int($line)) {
@@ -104,9 +110,6 @@ readonly class SecurityTxtCheckHostResultFactory
 				throw new SecurityTxtCannotParseJsonException("lineWarnings > {$line} is not an array");
 			}
 			$lineWarnings[$line] = $this->securityTxtJson->createViolationsFromJsonValues(array_values($violations));
-		}
-		if (!is_array($values['lineWarnings'])) {
-			throw new SecurityTxtCannotParseJsonException('lineWarnings is not an array');
 		}
 		if (!is_array($values['fileErrors'])) {
 			throw new SecurityTxtCannotParseJsonException('fileErrors is not an array');
@@ -126,6 +129,24 @@ readonly class SecurityTxtCheckHostResultFactory
 				throw new SecurityTxtCannotParseJsonException("securityTxt > {$field} is not an array");
 			}
 			$securityTxtFields[$field] = $fieldValues;
+		}
+		if (!is_bool($values['expiresSoon'])) {
+			throw new SecurityTxtCannotParseJsonException('expiresSoon is not a bool');
+		}
+		if ($values['expired'] !== null && !is_bool($values['expired'])) {
+			throw new SecurityTxtCannotParseJsonException('expired is not an int');
+		}
+		if ($values['expiryDays'] !== null && !is_int($values['expiryDays'])) {
+			throw new SecurityTxtCannotParseJsonException('expiryDays is not an int');
+		}
+		if (!is_bool($values['valid'])) {
+			throw new SecurityTxtCannotParseJsonException('valid is not a bool');
+		}
+		if (!is_bool($values['strictMode'])) {
+			throw new SecurityTxtCannotParseJsonException('strictMode is not a bool');
+		}
+		if ($values['expiresWarningThreshold'] !== null && !is_int($values['expiresWarningThreshold'])) {
+			throw new SecurityTxtCannotParseJsonException('expiresWarningThreshold is not an int');
 		}
 		return new SecurityTxtCheckHostResult(
 			$values['host'],

--- a/src/Check/SecurityTxtCheckHostResultFactory.php
+++ b/src/Check/SecurityTxtCheckHostResultFactory.php
@@ -9,13 +9,13 @@ use Spaze\SecurityTxt\Json\SecurityTxtJson;
 use Spaze\SecurityTxt\Parser\SecurityTxtParseResult;
 use Spaze\SecurityTxt\SecurityTxtFactory;
 
-class SecurityTxtCheckHostResultFactory
+readonly class SecurityTxtCheckHostResultFactory
 {
 
 	public function __construct(
-		private readonly SecurityTxtFactory $securityTxtFactory,
-		private readonly SecurityTxtJson $securityTxtJson,
-		private readonly SecurityTxtFetchResultFactory $securityTxtFetchResultFactory,
+		private SecurityTxtFactory $securityTxtFactory,
+		private SecurityTxtJson $securityTxtJson,
+		private SecurityTxtFetchResultFactory $securityTxtFetchResultFactory,
 	) {
 	}
 

--- a/src/Fetcher/Exceptions/SecurityTxtHostIpAddressInvalidTypeException.php
+++ b/src/Fetcher/Exceptions/SecurityTxtHostIpAddressInvalidTypeException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Fetcher\Exceptions;
+
+use Throwable;
+
+class SecurityTxtHostIpAddressInvalidTypeException extends SecurityTxtFetcherException
+{
+
+	public function __construct(string $host, string $type, string $url, ?Throwable $previous = null)
+	{
+		parent::__construct(func_get_args(), "IP address of %s is a %s, should be a string", [$host, $type], $url, previous: $previous);
+	}
+
+}

--- a/src/Fetcher/Exceptions/SecurityTxtHostIpAddressNotFoundException.php
+++ b/src/Fetcher/Exceptions/SecurityTxtHostIpAddressNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Fetcher\Exceptions;
+
+use Throwable;
+
+class SecurityTxtHostIpAddressNotFoundException extends SecurityTxtFetcherException
+{
+
+	public function __construct(string $url, string $host, ?Throwable $previous = null)
+	{
+		parent::__construct(func_get_args(), "Can't open %s, no IP address for %s found", [$url, $host], $url, previous: $previous);
+	}
+
+}

--- a/src/Fetcher/HttpClients/SecurityTxtFetcherFopenClient.php
+++ b/src/Fetcher/HttpClients/SecurityTxtFetcherFopenClient.php
@@ -31,7 +31,7 @@ class SecurityTxtFetcherFopenClient implements SecurityTxtFetcherHttpClient
 			$options['ssl'] = [
 				'peer_name' => $contextHost,
 			];
-			$options['http']['header'][] = "Host: {$contextHost}";
+			$options['http']['header'] = ["Host: {$contextHost}"];
 		}
 		$fp = @fopen($url->getUrl(), 'r', context: stream_context_create($options)); // intentionally @, converted to exception
 		if (!$fp) {

--- a/src/Fetcher/SecurityTxtFetchResult.php
+++ b/src/Fetcher/SecurityTxtFetchResult.php
@@ -6,7 +6,7 @@ namespace Spaze\SecurityTxt\Fetcher;
 use JsonSerializable;
 use Spaze\SecurityTxt\Violations\SecurityTxtSpecViolation;
 
-class SecurityTxtFetchResult implements JsonSerializable
+readonly class SecurityTxtFetchResult implements JsonSerializable
 {
 
 	/**
@@ -15,12 +15,12 @@ class SecurityTxtFetchResult implements JsonSerializable
 	 * @param list<SecurityTxtSpecViolation> $warnings
 	 */
 	public function __construct(
-		private readonly string $constructedUrl,
-		private readonly string $finalUrl,
-		private readonly array $redirects,
-		private readonly string $contents,
-		private readonly array $errors,
-		private readonly array $warnings,
+		private string $constructedUrl,
+		private string $finalUrl,
+		private array $redirects,
+		private string $contents,
+		private array $errors,
+		private array $warnings,
 	) {
 	}
 

--- a/src/Fetcher/SecurityTxtFetchResultFactory.php
+++ b/src/Fetcher/SecurityTxtFetchResultFactory.php
@@ -6,11 +6,11 @@ namespace Spaze\SecurityTxt\Fetcher;
 use Spaze\SecurityTxt\Check\Exceptions\SecurityTxtCannotParseJsonException;
 use Spaze\SecurityTxt\Json\SecurityTxtJson;
 
-class SecurityTxtFetchResultFactory
+readonly class SecurityTxtFetchResultFactory
 {
 
 	public function __construct(
-		private readonly SecurityTxtJson $securityTxtJson,
+		private SecurityTxtJson $securityTxtJson,
 	) {
 	}
 

--- a/src/Fetcher/SecurityTxtFetcher.php
+++ b/src/Fetcher/SecurityTxtFetcher.php
@@ -24,7 +24,7 @@ use Spaze\SecurityTxt\Violations\SecurityTxtWellKnownPathOnly;
 class SecurityTxtFetcher
 {
 
-	private const MAX_ALLOWED_REDIRECTS = 5;
+	private const int MAX_ALLOWED_REDIRECTS = 5;
 
 	/** @var array<string, list<string>> */
 	private array $redirects = [];

--- a/src/Fetcher/SecurityTxtFetcherFetchHostResult.php
+++ b/src/Fetcher/SecurityTxtFetcherFetchHostResult.php
@@ -9,14 +9,14 @@ use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtFetcherException;
 /**
  * @internal
  */
-class SecurityTxtFetcherFetchHostResult implements JsonSerializable
+readonly class SecurityTxtFetcherFetchHostResult implements JsonSerializable
 {
 
 	public function __construct(
-		private readonly string $url,
-		private readonly string $finalUrl,
-		private readonly ?SecurityTxtFetcherResponse $response,
-		private readonly ?SecurityTxtFetcherException $exception,
+		private string $url,
+		private string $finalUrl,
+		private ?SecurityTxtFetcherResponse $response,
+		private ?SecurityTxtFetcherException $exception,
 	) {
 	}
 

--- a/src/Fetcher/SecurityTxtFetcherResponse.php
+++ b/src/Fetcher/SecurityTxtFetcherResponse.php
@@ -5,16 +5,16 @@ namespace Spaze\SecurityTxt\Fetcher;
 
 use JsonSerializable;
 
-class SecurityTxtFetcherResponse implements JsonSerializable
+readonly class SecurityTxtFetcherResponse implements JsonSerializable
 {
 
 	/**
 	 * @param array<string, string> $headers lowercase name => value
 	 */
 	public function __construct(
-		private readonly int $httpCode,
-		private readonly array $headers,
-		private readonly string $contents,
+		private int $httpCode,
+		private array $headers,
+		private string $contents,
 	) {
 	}
 

--- a/src/Fetcher/SecurityTxtFetcherUrl.php
+++ b/src/Fetcher/SecurityTxtFetcherUrl.php
@@ -3,15 +3,15 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fetcher;
 
-class SecurityTxtFetcherUrl
+readonly class SecurityTxtFetcherUrl
 {
 
 	/**
 	 * @param list<string> $redirects
 	 */
 	public function __construct(
-		private readonly string $url,
-		private readonly array $redirects,
+		private string $url,
+		private array $redirects,
 	) {
 	}
 

--- a/src/Fields/Expires.php
+++ b/src/Fields/Expires.php
@@ -16,7 +16,7 @@ class Expires implements JsonSerializable
 	public function __construct(
 		private readonly DateTimeImmutable $dateTime,
 	) {
-		$this->interval = (new DateTimeImmutable())->diff($this->dateTime);
+		$this->interval = new DateTimeImmutable()->diff($this->dateTime);
 	}
 
 

--- a/src/Fields/PreferredLanguages.php
+++ b/src/Fields/PreferredLanguages.php
@@ -5,14 +5,14 @@ namespace Spaze\SecurityTxt\Fields;
 
 use JsonSerializable;
 
-class PreferredLanguages implements JsonSerializable
+readonly class PreferredLanguages implements JsonSerializable
 {
 
 	/**
 	 * @param list<string> $languages
 	 */
 	public function __construct(
-		private readonly array $languages,
+		private array $languages,
 	) {
 	}
 

--- a/src/Json/SecurityTxtJson.php
+++ b/src/Json/SecurityTxtJson.php
@@ -42,6 +42,9 @@ class SecurityTxtJson
 	{
 		$redirects = [];
 		foreach ($values as $url => $urlRedirects) {
+			if (!is_string($url)) {
+				throw new SecurityTxtCannotParseJsonException(sprintf('redirects key is a %s not a string', get_debug_type($url)));
+			}
 			if (!is_array($urlRedirects)) {
 				throw new SecurityTxtCannotParseJsonException("redirects > {$url} is not an array");
 			}

--- a/src/Parser/SecurityTxtParseResult.php
+++ b/src/Parser/SecurityTxtParseResult.php
@@ -9,7 +9,7 @@ use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\Validator\SecurityTxtValidateResult;
 use Spaze\SecurityTxt\Violations\SecurityTxtSpecViolation;
 
-class SecurityTxtParseResult implements JsonSerializable
+readonly class SecurityTxtParseResult implements JsonSerializable
 {
 
 	/**
@@ -17,15 +17,15 @@ class SecurityTxtParseResult implements JsonSerializable
 	 * @param array<int, list<SecurityTxtSpecViolation>> $lineWarnings
 	 */
 	public function __construct(
-		private readonly SecurityTxt $securityTxt,
-		private readonly bool $isValid,
-		private readonly bool $strictMode,
-		private readonly ?int $expiresWarningThreshold,
-		private readonly bool $expiresSoon,
-		private readonly array $lineErrors,
-		private readonly array $lineWarnings,
-		private readonly SecurityTxtValidateResult $validateResult,
-		private readonly ?SecurityTxtFetchResult $fetchResult = null,
+		private SecurityTxt $securityTxt,
+		private bool $isValid,
+		private bool $strictMode,
+		private ?int $expiresWarningThreshold,
+		private bool $expiresSoon,
+		private array $lineErrors,
+		private array $lineWarnings,
+		private SecurityTxtValidateResult $validateResult,
+		private ?SecurityTxtFetchResult $fetchResult = null,
 	) {
 	}
 

--- a/src/Parser/SecurityTxtParser.php
+++ b/src/Parser/SecurityTxtParser.php
@@ -8,6 +8,8 @@ use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtWarning;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotOpenUrlException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotReadUrlException;
+use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtHostIpAddressInvalidTypeException;
+use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtHostIpAddressNotFoundException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtHostNotFoundException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtNoHttpCodeException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtNoLocationHeaderException;
@@ -30,6 +32,7 @@ use Spaze\SecurityTxt\Parser\FieldProcessors\PreferredLanguagesCheckMultipleFiel
 use Spaze\SecurityTxt\Parser\FieldProcessors\PreferredLanguagesSetFieldValue;
 use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\SecurityTxtValidationLevel;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtCannotVerifySignatureException;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignature;
 use Spaze\SecurityTxt\Validator\SecurityTxtValidator;
 use Spaze\SecurityTxt\Violations\SecurityTxtLineNoEol;
@@ -111,6 +114,9 @@ class SecurityTxtParser
 	}
 
 
+	/**
+	 * @throws SecurityTxtCannotVerifySignatureException
+	 */
 	public function parseString(string $contents, ?int $expiresWarningThreshold = null, bool $strictMode = false): SecurityTxtParseResult
 	{
 		$this->lineErrors = [];
@@ -177,6 +183,9 @@ class SecurityTxtParser
 	 * @throws SecurityTxtNoHttpCodeException
 	 * @throws SecurityTxtNoLocationHeaderException
 	 * @throws SecurityTxtOnlyIpv6HostButIpv6DisabledException
+	 * @throws SecurityTxtHostIpAddressInvalidTypeException
+	 * @throws SecurityTxtHostIpAddressNotFoundException
+	 * @throws SecurityTxtCannotVerifySignatureException
 	 */
 	public function parseHost(string $host, ?int $expiresWarningThreshold = null, bool $strictMode = false, bool $noIpv6 = false): SecurityTxtParseResult
 	{
@@ -186,6 +195,9 @@ class SecurityTxtParser
 	}
 
 
+	/**
+	 * @throws SecurityTxtCannotVerifySignatureException
+	 */
 	public function parseFetchResult(SecurityTxtFetchResult $fetchResult, ?int $expiresWarningThreshold = null, bool $strictMode = false): SecurityTxtParseResult
 	{
 		$parseResult = $this->parseString($fetchResult->getContents(), $expiresWarningThreshold, $strictMode);
@@ -193,6 +205,9 @@ class SecurityTxtParser
 	}
 
 
+	/**
+	 * @throws SecurityTxtCannotVerifySignatureException
+	 */
 	private function checkSignature(int $lineNumber, string $line, string $contents, SecurityTxt $securityTxt): void
 	{
 		if ($this->signature->isCleartextHeader($line)) {

--- a/src/SecurityTxtFactory.php
+++ b/src/SecurityTxtFactory.php
@@ -106,7 +106,7 @@ class SecurityTxtFactory
 	private function addSecurityTxtUriField(array $values, string $field, string $class, callable $addField): void
 	{
 		if (!is_array($values[$field])) {
-			throw new SecurityTxtCannotParseJsonException("Field {field} is not an array");
+			throw new SecurityTxtCannotParseJsonException("Field {$field} is not an array");
 		}
 		foreach ($values[$field] as $value) {
 			if (!is_array($value)) {

--- a/src/SecurityTxtFactory.php
+++ b/src/SecurityTxtFactory.php
@@ -98,7 +98,7 @@ class SecurityTxtFactory
 
 	/**
 	 * @template T of SecurityTxtUriField
-	 * @param array<mixed, mixed> $values
+	 * @param array<array-key, mixed> $values
 	 * @param callable(T): void $addField
 	 * @param class-string<T> $class
 	 * @throws SecurityTxtCannotParseJsonException

--- a/src/Signature/Exceptions/SecurityTxtCannotVerifySignatureException.php
+++ b/src/Signature/Exceptions/SecurityTxtCannotVerifySignatureException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Signature\Exceptions;
+
+use Exception;
+use Throwable;
+
+class SecurityTxtCannotVerifySignatureException extends Exception
+{
+
+	public function __construct(string $message, ?Throwable $previous = null)
+	{
+		parent::__construct("Cannot verify signature: {$message}", previous: $previous);
+	}
+
+}

--- a/src/Signature/SecurityTxtSignature.php
+++ b/src/Signature/SecurityTxtSignature.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use gnupg;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtWarning;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtCannotVerifySignatureException;
 use Spaze\SecurityTxt\Violations\SecurityTxtSignatureExtensionNotLoaded;
 use Spaze\SecurityTxt\Violations\SecurityTxtSignatureInvalid;
 
@@ -38,6 +39,7 @@ class SecurityTxtSignature
 	/**
 	 * @throws SecurityTxtError
 	 * @throws SecurityTxtWarning
+	 * @throws SecurityTxtCannotVerifySignatureException
 	 */
 	public function verify(string $contents): SecurityTxtSignatureVerifyResult
 	{
@@ -47,8 +49,20 @@ class SecurityTxtSignature
 			throw new SecurityTxtError(new SecurityTxtSignatureInvalid());
 		}
 		$signature = $signatures[0];
+		if (!is_array($signature)) {
+			throw new SecurityTxtCannotVerifySignatureException('signature is not an array');
+		}
+		if (!isset($signature['summary']) || !is_int($signature['summary'])) {
+			throw new SecurityTxtCannotVerifySignatureException('summary is missing or not a string');
+		}
 		if (!$this->isSignatureKindaOkay($signature['summary'])) {
 			throw new SecurityTxtError(new SecurityTxtSignatureInvalid());
+		}
+		if (!isset($signature['fingerprint']) || !is_string($signature['fingerprint'])) {
+			throw new SecurityTxtCannotVerifySignatureException('fingerprint is missing or not a string');
+		}
+		if (!isset($signature['timestamp']) || !is_int($signature['timestamp'])) {
+			throw new SecurityTxtCannotVerifySignatureException('timestamp is missing or not a string');
 		}
 		return new SecurityTxtSignatureVerifyResult($signature['fingerprint'], new DateTimeImmutable()->setTimestamp($signature['timestamp']));
 	}

--- a/src/Signature/SecurityTxtSignature.php
+++ b/src/Signature/SecurityTxtSignature.php
@@ -50,7 +50,7 @@ class SecurityTxtSignature
 		if (!$this->isSignatureKindaOkay($signature['summary'])) {
 			throw new SecurityTxtError(new SecurityTxtSignatureInvalid());
 		}
-		return new SecurityTxtSignatureVerifyResult($signature['fingerprint'], (new DateTimeImmutable())->setTimestamp($signature['timestamp']));
+		return new SecurityTxtSignatureVerifyResult($signature['fingerprint'], new DateTimeImmutable()->setTimestamp($signature['timestamp']));
 	}
 
 

--- a/src/Signature/SecurityTxtSignatureVerifyResult.php
+++ b/src/Signature/SecurityTxtSignatureVerifyResult.php
@@ -6,12 +6,12 @@ namespace Spaze\SecurityTxt\Signature;
 use DateTimeImmutable;
 use JsonSerializable;
 
-class SecurityTxtSignatureVerifyResult implements JsonSerializable
+readonly class SecurityTxtSignatureVerifyResult implements JsonSerializable
 {
 
 	public function __construct(
-		private readonly string $keyFingerprint,
-		private readonly DateTimeImmutable $date,
+		private string $keyFingerprint,
+		private DateTimeImmutable $date,
 	) {
 	}
 

--- a/src/Validator/SecurityTxtValidateResult.php
+++ b/src/Validator/SecurityTxtValidateResult.php
@@ -6,7 +6,7 @@ namespace Spaze\SecurityTxt\Validator;
 use JsonSerializable;
 use Spaze\SecurityTxt\Violations\SecurityTxtSpecViolation;
 
-class SecurityTxtValidateResult implements JsonSerializable
+readonly class SecurityTxtValidateResult implements JsonSerializable
 {
 
 	/**
@@ -14,8 +14,8 @@ class SecurityTxtValidateResult implements JsonSerializable
 	 * @param list<SecurityTxtSpecViolation> $warnings
 	 */
 	public function __construct(
-		private readonly array $errors,
-		private readonly array $warnings,
+		private array $errors,
+		private array $warnings,
 	) {
 	}
 

--- a/src/Violations/SecurityTxtExpired.php
+++ b/src/Violations/SecurityTxtExpired.php
@@ -15,7 +15,7 @@ class SecurityTxtExpired extends SecurityTxtSpecViolation
 			'The file is considered stale and should not be used',
 			[],
 			'draft-foudil-securitytxt-09',
-			(new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339),
+			new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339),
 			'The `Expires` field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
 			[],
 			'2.5.5',

--- a/src/Violations/SecurityTxtExpiresTooLong.php
+++ b/src/Violations/SecurityTxtExpiresTooLong.php
@@ -10,7 +10,7 @@ class SecurityTxtExpiresTooLong extends SecurityTxtSpecViolation
 
 	public function __construct()
 	{
-		$correctValue = (new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339);
+		$correctValue = new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339);
 		parent::__construct(
 			func_get_args(),
 			'The value of the `Expires` should be less than a year into the future to avoid staleness',

--- a/src/Violations/SecurityTxtExpiresWrongFormat.php
+++ b/src/Violations/SecurityTxtExpiresWrongFormat.php
@@ -11,7 +11,7 @@ class SecurityTxtExpiresWrongFormat extends SecurityTxtSpecViolation
 
 	public function __construct(?DateTimeInterface $expires = null)
 	{
-		$correctValue = $expires ? $expires->format(DATE_RFC3339) : (new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339);
+		$correctValue = $expires ? $expires->format(DATE_RFC3339) : new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339);
 		parent::__construct(
 			func_get_args(),
 			'The format of the value of the `Expires` field is wrong',

--- a/src/Violations/SecurityTxtNoExpires.php
+++ b/src/Violations/SecurityTxtNoExpires.php
@@ -15,7 +15,7 @@ class SecurityTxtNoExpires extends SecurityTxtSpecViolation
 			'The `Expires` field must always be present',
 			[],
 			'draft-foudil-securitytxt-10',
-			(new DateTimeImmutable('+1 year midnight -1 sec'))->format(DATE_RFC3339),
+			new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339),
 			'Add an `Expires` field with a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
 			[],
 			'2.5.5',

--- a/tests/Check/SecurityTxtCheckHostResultFactoryTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostResultFactoryTest.phpt
@@ -92,4 +92,4 @@ class SecurityTxtCheckHostResultFactoryTest extends TestCase
 
 }
 
-(new SecurityTxtCheckHostResultFactoryTest())->run();
+new SecurityTxtCheckHostResultFactoryTest()->run();

--- a/tests/Check/SecurityTxtCheckHostTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostTest.phpt
@@ -246,4 +246,4 @@ class SecurityTxtCheckHostTest extends TestCase
 
 }
 
-(new SecurityTxtCheckHostTest())->run();
+new SecurityTxtCheckHostTest()->run();

--- a/tests/Fetcher/SecurityTxtFetchResultFactoryTest.phpt
+++ b/tests/Fetcher/SecurityTxtFetchResultFactoryTest.phpt
@@ -36,4 +36,4 @@ class SecurityTxtFetchResultFactoryTest extends TestCase
 
 }
 
-(new SecurityTxtFetchResultFactoryTest())->run();
+new SecurityTxtFetchResultFactoryTest()->run();

--- a/tests/Fetcher/SecurityTxtFetcherTest.phpt
+++ b/tests/Fetcher/SecurityTxtFetcherTest.phpt
@@ -1,6 +1,5 @@
 <?php
 /** @noinspection PhpUnhandledExceptionInspection */
-/** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
 /** @noinspection PhpFullyQualifiedNameUsageInspection */
 declare(strict_types = 1);
 

--- a/tests/Fetcher/SecurityTxtFetcherTest.phpt
+++ b/tests/Fetcher/SecurityTxtFetcherTest.phpt
@@ -171,4 +171,4 @@ class SecurityTxtFetcherTest extends TestCase
 
 }
 
-(new SecurityTxtFetcherTest())->run();
+new SecurityTxtFetcherTest()->run();

--- a/tests/Fetcher/SecurityTxtFetcherTest.phpt
+++ b/tests/Fetcher/SecurityTxtFetcherTest.phpt
@@ -161,9 +161,9 @@ class SecurityTxtFetcherTest extends TestCase
 	 */
 	public function testGetResultNotFound(): void
 	{
-		$wellKnown = new SecurityTxtFetcherFetchHostResult('foo', 'foo2', null, new SecurityTxtUrlNotFoundException('foo', 404));
-		$topLevel = new SecurityTxtFetcherFetchHostResult('bar', 'bar2', null, new SecurityTxtUrlNotFoundException('bar', 403));
-		Assert::with($this->securityTxtFetcher, function () use ($wellKnown, $topLevel): void {
+		Assert::with($this->securityTxtFetcher, function (): void {
+			$wellKnown = new SecurityTxtFetcherFetchHostResult('foo', 'foo2', null, new SecurityTxtUrlNotFoundException('foo', 404));
+			$topLevel = new SecurityTxtFetcherFetchHostResult('bar', 'bar2', null, new SecurityTxtUrlNotFoundException('bar', 403));
 			/** @noinspection PhpUndefinedMethodInspection Closure bound to $this->securityTxtFetcher */
 			$this->getResult($wellKnown, $topLevel);
 		});

--- a/tests/Fields/AcknowledgmentsTest.phpt
+++ b/tests/Fields/AcknowledgmentsTest.phpt
@@ -29,4 +29,4 @@ class AcknowledgmentsTest extends TestCase
 
 }
 
-(new AcknowledgmentsTest())->run();
+new AcknowledgmentsTest()->run();

--- a/tests/Fields/CanonicalTest.phpt
+++ b/tests/Fields/CanonicalTest.phpt
@@ -28,4 +28,4 @@ class CanonicalTest extends TestCase
 
 }
 
-(new CanonicalTest())->run();
+new CanonicalTest()->run();

--- a/tests/Fields/ContactTest.phpt
+++ b/tests/Fields/ContactTest.phpt
@@ -30,4 +30,4 @@ class ContactTest extends TestCase
 
 }
 
-(new ContactTest())->run();
+new ContactTest()->run();

--- a/tests/Fields/EncryptionTest.phpt
+++ b/tests/Fields/EncryptionTest.phpt
@@ -29,4 +29,4 @@ class EncryptionTest extends TestCase
 
 }
 
-(new EncryptionTest())->run();
+new EncryptionTest()->run();

--- a/tests/Fields/ExpiresTest.phpt
+++ b/tests/Fields/ExpiresTest.phpt
@@ -41,4 +41,4 @@ class ExpiresTest extends TestCase
 
 }
 
-(new ExpiresTest())->run();
+new ExpiresTest()->run();

--- a/tests/Fields/HiringTest.phpt
+++ b/tests/Fields/HiringTest.phpt
@@ -29,4 +29,4 @@ class HiringTest extends TestCase
 
 }
 
-(new HiringTest())->run();
+new HiringTest()->run();

--- a/tests/Fields/PolicyTest.phpt
+++ b/tests/Fields/PolicyTest.phpt
@@ -29,4 +29,4 @@ class PolicyTest extends TestCase
 
 }
 
-(new PolicyTest())->run();
+new PolicyTest()->run();

--- a/tests/Fields/PreferredLanguagesTest.phpt
+++ b/tests/Fields/PreferredLanguagesTest.phpt
@@ -29,4 +29,4 @@ class PreferredLanguagesTest extends TestCase
 
 }
 
-(new PreferredLanguagesTest())->run();
+new PreferredLanguagesTest()->run();

--- a/tests/Parser/FieldProcessors/AcknowledgmentsAddFieldValueTest.phpt
+++ b/tests/Parser/FieldProcessors/AcknowledgmentsAddFieldValueTest.phpt
@@ -45,4 +45,4 @@ class AcknowledgmentsAddFieldValueTest extends TestCase
 
 }
 
-(new AcknowledgmentsAddFieldValueTest())->run();
+new AcknowledgmentsAddFieldValueTest()->run();

--- a/tests/Parser/FieldProcessors/EncryptionAddFieldValueTest.phpt
+++ b/tests/Parser/FieldProcessors/EncryptionAddFieldValueTest.phpt
@@ -45,4 +45,4 @@ class EncryptionAddFieldValueTest extends TestCase
 
 }
 
-(new EncryptionAddFieldValueTest())->run();
+new EncryptionAddFieldValueTest()->run();

--- a/tests/Parser/FieldProcessors/ExpiresSetFieldValueTest.phpt
+++ b/tests/Parser/FieldProcessors/ExpiresSetFieldValueTest.phpt
@@ -48,4 +48,4 @@ class ExpiresSetFieldValueTest extends TestCase
 
 }
 
-(new ExpiresSetFieldValueTest())->run();
+new ExpiresSetFieldValueTest()->run();

--- a/tests/Parser/FieldProcessors/HiringAddFieldValueTest.phpt
+++ b/tests/Parser/FieldProcessors/HiringAddFieldValueTest.phpt
@@ -45,4 +45,4 @@ class HiringAddFieldValueTest extends TestCase
 
 }
 
-(new HiringAddFieldValueTest())->run();
+new HiringAddFieldValueTest()->run();

--- a/tests/Parser/FieldProcessors/PolicyAddFieldValueTest.phpt
+++ b/tests/Parser/FieldProcessors/PolicyAddFieldValueTest.phpt
@@ -45,4 +45,4 @@ class PolicyAddFieldValueTest extends TestCase
 
 }
 
-(new PolicyAddFieldValueTest())->run();
+new PolicyAddFieldValueTest()->run();

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -7,7 +7,6 @@ namespace Spaze\SecurityTxt\Parser;
 use DateTime;
 use DateTimeImmutable;
 use Spaze\SecurityTxt\Fetcher\HttpClients\SecurityTxtFetcherFopenClient;
-use Spaze\SecurityTxt\Fetcher\HttpClients\SecurityTxtFetcherHttpClient;
 use Spaze\SecurityTxt\Fetcher\SecurityTxtFetcher;
 use Spaze\SecurityTxt\Fetcher\SecurityTxtFetchResult;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignature;
@@ -86,7 +85,7 @@ class SecurityTxtParserTest extends TestCase
 	{
 		$contents = "Expires: Mon, 15 Aug 2005 15:52:01 +0000\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
-		/** @var \Spaze\SecurityTxt\Violations\SecurityTxtExpiresOldFormat $expiresError */
+		/** @var SecurityTxtExpiresOldFormat $expiresError */
 		$expiresError = $parseResult->getLineErrors()[1][0];
 		Assert::type(SecurityTxtExpiresOldFormat::class, $expiresError);
 		Assert::same('2005-08-15T15:52:01+00:00', $expiresError->getCorrectValue());

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -37,19 +37,14 @@ class SecurityTxtParserTest extends TestCase
 {
 
 	private SecurityTxtParser $securityTxtParser;
-	private SecurityTxtValidator $securityTxtValidator;
-	private SecurityTxtSignature $securityTxtSignature;
-	private SecurityTxtFetcher $securityTxtFetcher;
-	private SecurityTxtFetcherHttpClient $securityTxtFetcherHttpClient;
-
 
 	protected function setUp(): void
 	{
-		$this->securityTxtValidator = new SecurityTxtValidator();
-		$this->securityTxtSignature = new SecurityTxtSignature();
-		$this->securityTxtFetcherHttpClient = new SecurityTxtFetcherFopenClient();
-		$this->securityTxtFetcher = new SecurityTxtFetcher($this->securityTxtFetcherHttpClient);
-		$this->securityTxtParser = new SecurityTxtParser($this->securityTxtValidator, $this->securityTxtSignature, $this->securityTxtFetcher);
+		$securityTxtValidator = new SecurityTxtValidator();
+		$securityTxtSignature = new SecurityTxtSignature();
+		$securityTxtFetcherHttpClient = new SecurityTxtFetcherFopenClient();
+		$securityTxtFetcher = new SecurityTxtFetcher($securityTxtFetcherHttpClient);
+		$this->securityTxtParser = new SecurityTxtParser($securityTxtValidator, $securityTxtSignature, $securityTxtFetcher);
 	}
 
 

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -65,7 +65,7 @@ class SecurityTxtParserTest extends TestCase
 	/** @dataProvider getExpiresField */
 	public function testParseStringExpiresField(string $fieldValue, bool $isExpired, array $errors): void
 	{
-		$contents = "Foo: bar\nExpires: " . (new DateTime($fieldValue))->format(DATE_RFC3339) . "\nBar: foo\n";
+		$contents = "Foo: bar\nExpires: " . new DateTime($fieldValue)->format(DATE_RFC3339) . "\nBar: foo\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		Assert::same($isExpired, $parseResult->getSecurityTxt()->getExpires()->isExpired());
 		foreach ($parseResult->getLineErrors() as $lineNumber => $lineErrors) {
@@ -110,7 +110,7 @@ class SecurityTxtParserTest extends TestCase
 
 	public function testParseStringMultipleExpires(): void
 	{
-		$contents = "Foo: bar\nExpires: " . (new DateTime('+2 months'))->format(DATE_RFC3339) . "\nExpires: " . (new DateTime('+3 months'))->format(DATE_RFC3339) . "\nBar: foo\n";
+		$contents = "Foo: bar\nExpires: " . new DateTime('+2 months')->format(DATE_RFC3339) . "\nExpires: " . new DateTime('+3 months')->format(DATE_RFC3339) . "\nBar: foo\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		$expiresError = $parseResult->getLineErrors()[3][0];
 		Assert::type(SecurityTxtMultipleExpires::class, $expiresError);
@@ -128,7 +128,7 @@ class SecurityTxtParserTest extends TestCase
 
 	public function testParseStringMultipleExpiresFirstWrong(): void
 	{
-		$contents = "Foo: bar\nExpires: Mon, 15 Aug 2005 15:52:01 +0000\nExpires: " . (new DateTime('+2 months'))->format(DATE_RFC3339) . "\nBar: foo\n";
+		$contents = "Foo: bar\nExpires: Mon, 15 Aug 2005 15:52:01 +0000\nExpires: " . new DateTime('+2 months')->format(DATE_RFC3339) . "\nBar: foo\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		Assert::type(SecurityTxtExpiresOldFormat::class, $parseResult->getLineErrors()[2][0]);
 	}
@@ -136,7 +136,7 @@ class SecurityTxtParserTest extends TestCase
 
 	public function testParseStringMultipleExpiresFirstCorrect(): void
 	{
-		$contents = "Foo: bar\nExpires: " . (new DateTime('+2 months'))->format(DATE_RFC3339) . "\nExpires: Mon, 15 Aug 2005 15:52:01 +0000\nBar: foo\n";
+		$contents = "Foo: bar\nExpires: " . new DateTime('+2 months')->format(DATE_RFC3339) . "\nExpires: Mon, 15 Aug 2005 15:52:01 +0000\nBar: foo\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		Assert::count(2, $parseResult->getLineErrors()[3]);
 		Assert::type(SecurityTxtMultipleExpires::class, $parseResult->getLineErrors()[3][0]);
@@ -154,14 +154,14 @@ class SecurityTxtParserTest extends TestCase
 			Assert::count(0, $parseResult->getLineErrors());
 			Assert::count(0, $parseResult->getFileErrors());
 		};
-		$assertParsed('mailto:foo@bar.example', (new DateTime('+2 months'))->format(DATE_RFC3339));
-		$assertParsed('mailto:bar@foo.example', (new DateTime('+3 months'))->format(DATE_RFC3339));
+		$assertParsed('mailto:foo@bar.example', new DateTime('+2 months')->format(DATE_RFC3339));
+		$assertParsed('mailto:bar@foo.example', new DateTime('+3 months')->format(DATE_RFC3339));
 	}
 
 
 	public function testParseMultipleBadFiles(): void
 	{
-		$contents = "Foo: bar\nExpires: " . (new DateTime('+2 months'))->format(DATE_RFC3339) . "\nExpires: " . (new DateTime('+3 months'))->format(DATE_RFC3339) . "\nBar: foo\n";
+		$contents = "Foo: bar\nExpires: " . new DateTime('+2 months')->format(DATE_RFC3339) . "\nExpires: " . new DateTime('+3 months')->format(DATE_RFC3339) . "\nBar: foo\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		Assert::type(SecurityTxtMultipleExpires::class, $parseResult->getLineErrors()[3][0]);
 
@@ -173,7 +173,7 @@ class SecurityTxtParserTest extends TestCase
 
 	public function testParseStringExpiresTooLong(): void
 	{
-		$contents = "Foo: bar\nExpires: " . (new DateTime('+2 years'))->format(DATE_RFC3339) . "\n";
+		$contents = "Foo: bar\nExpires: " . new DateTime('+2 years')->format(DATE_RFC3339) . "\n";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		Assert::count(0, $parseResult->getLineErrors());
 		Assert::count(1, $parseResult->getLineWarnings());
@@ -193,7 +193,7 @@ class SecurityTxtParserTest extends TestCase
 
 	public function testParseStringNoEol(): void
 	{
-		$contents = 'Expires: ' . (new DateTime('+3 months'))->format(DATE_RFC3339) . "\nContact: https://foo.example/";
+		$contents = 'Expires: ' . new DateTime('+3 months')->format(DATE_RFC3339) . "\nContact: https://foo.example/";
 		$parseResult = $this->securityTxtParser->parseString($contents);
 		Assert::count(1, $parseResult->getLineErrors());
 		Assert::count(1, $parseResult->getLineErrors()[2]);
@@ -340,4 +340,4 @@ class SecurityTxtParserTest extends TestCase
 
 }
 
-(new SecurityTxtParserTest())->run();
+new SecurityTxtParserTest()->run();

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -37,6 +37,7 @@ class SecurityTxtParserTest extends TestCase
 
 	private SecurityTxtParser $securityTxtParser;
 
+
 	protected function setUp(): void
 	{
 		$securityTxtValidator = new SecurityTxtValidator();

--- a/tests/Parser/SecurityTxtUrlParserTest.phpt
+++ b/tests/Parser/SecurityTxtUrlParserTest.phpt
@@ -63,4 +63,4 @@ class SecurityTxtUrlParserTest extends TestCase
 
 }
 
-(new SecurityTxtUrlParserTest())->run();
+new SecurityTxtUrlParserTest()->run();

--- a/tests/SecurityTxtTest.phpt
+++ b/tests/SecurityTxtTest.phpt
@@ -265,4 +265,4 @@ class SecurityTxtTest extends TestCase
 
 }
 
-(new SecurityTxtTest())->run();
+new SecurityTxtTest()->run();

--- a/tests/Validator/SecurityTxtValidatorTest.phpt
+++ b/tests/Validator/SecurityTxtValidatorTest.phpt
@@ -69,4 +69,4 @@ class SecurityTxtValidatorTest extends TestCase
 
 }
 
-(new SecurityTxtValidatorTest())->run();
+new SecurityTxtValidatorTest()->run();


### PR DESCRIPTION
- Update the code to pass new PHPStan level 10 (the new max)
- Code cleanup as per PHPStorm's warnings
- Use the new PHP 8.4 features, some of them (property hooks not yet supported by the codesniffer, so not using them yet)
- Require PHP 8.4