### PR TITLE
Add SecurityTxtWriter to write a SecurityTxt object to a string

### DIFF
--- a/src/Fetcher/SecurityTxtFetcher.php
+++ b/src/Fetcher/SecurityTxtFetcher.php
@@ -16,6 +16,7 @@ use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtOnlyIpv6HostButIpv6DisabledE
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtTooManyRedirectsException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtUrlNotFoundException;
 use Spaze\SecurityTxt\Fetcher\HttpClients\SecurityTxtFetcherHttpClient;
+use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\Violations\SecurityTxtContentTypeInvalid;
 use Spaze\SecurityTxt\Violations\SecurityTxtContentTypeWrongCharset;
 use Spaze\SecurityTxt\Violations\SecurityTxtSchemeNotHttps;
@@ -192,9 +193,9 @@ final class SecurityTxtFetcher
 		$headerParts = $contentTypeHeader !== null ? explode(';', $contentTypeHeader, 2) : [];
 		$contentType = isset($headerParts[0]) ? trim($headerParts[0]) : null;
 		$charset = isset($headerParts[1]) ? trim($headerParts[1]) : null;
-		if ($contentType === null || strtolower($contentType) !== 'text/plain') {
+		if ($contentType === null || strtolower($contentType) !== SecurityTxt::CONTENT_TYPE) {
 			$errors[] = new SecurityTxtContentTypeInvalid($result->getUrl(), $contentType);
-		} elseif ($charset === null || strtolower($charset) !== 'charset=utf-8') {
+		} elseif ($charset === null || strtolower($charset) !== SecurityTxt::CHARSET) {
 			$errors[] = new SecurityTxtContentTypeWrongCharset($result->getUrl(), $contentType, $charset);
 		}
 		$scheme = parse_url($result->getUrl(), PHP_URL_SCHEME);

--- a/src/Fields/Acknowledgments.php
+++ b/src/Fields/Acknowledgments.php
@@ -3,6 +3,15 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fields;
 
-final class Acknowledgments extends SecurityTxtUriField
+use Override;
+
+final class Acknowledgments extends SecurityTxtUriField implements SecurityTxtFieldValue
 {
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Acknowledgments;
+	}
+
 }

--- a/src/Fields/Canonical.php
+++ b/src/Fields/Canonical.php
@@ -3,6 +3,15 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fields;
 
-final class Canonical extends SecurityTxtUriField
+use Override;
+
+final class Canonical extends SecurityTxtUriField implements SecurityTxtFieldValue
 {
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Canonical;
+	}
+
 }

--- a/src/Fields/Contact.php
+++ b/src/Fields/Contact.php
@@ -3,6 +3,27 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fields;
 
-final class Contact extends SecurityTxtUriField
+use Override;
+
+final class Contact extends SecurityTxtUriField implements SecurityTxtFieldValue
 {
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Contact;
+	}
+
+
+	public static function email(string $email): self
+	{
+		return new self('mailto:' . $email);
+	}
+
+
+	public static function phone(string $phone): self
+	{
+		return new self('tel:' . $phone);
+	}
+
 }

--- a/src/Fields/Encryption.php
+++ b/src/Fields/Encryption.php
@@ -3,6 +3,15 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fields;
 
-final class Encryption extends SecurityTxtUriField
+use Override;
+
+final class Encryption extends SecurityTxtUriField implements SecurityTxtFieldValue
 {
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Encryption;
+	}
+
 }

--- a/src/Fields/Expires.php
+++ b/src/Fields/Expires.php
@@ -8,8 +8,13 @@ use DateTimeImmutable;
 use JsonSerializable;
 use Override;
 
-final class Expires implements JsonSerializable
+final class Expires implements SecurityTxtFieldValue, JsonSerializable
 {
+
+	/**
+	 * @internal
+	 */
+	public const string FORMAT = DATE_RFC3339;
 
 	private DateInterval $interval;
 
@@ -18,6 +23,20 @@ final class Expires implements JsonSerializable
 		private readonly DateTimeImmutable $dateTime,
 	) {
 		$this->interval = new DateTimeImmutable()->diff($this->dateTime);
+	}
+
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Expires;
+	}
+
+
+	#[Override]
+	public function getValue(): string
+	{
+		return $this->dateTime->format(Expires::FORMAT);
 	}
 
 

--- a/src/Fields/Hiring.php
+++ b/src/Fields/Hiring.php
@@ -3,6 +3,15 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fields;
 
-final class Hiring extends SecurityTxtUriField
+use Override;
+
+final class Hiring extends SecurityTxtUriField implements SecurityTxtFieldValue
 {
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Hiring;
+	}
+
 }

--- a/src/Fields/Policy.php
+++ b/src/Fields/Policy.php
@@ -3,6 +3,15 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fields;
 
-final class Policy extends SecurityTxtUriField
+use Override;
+
+final class Policy extends SecurityTxtUriField implements SecurityTxtFieldValue
 {
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::Policy;
+	}
+
 }

--- a/src/Fields/PreferredLanguages.php
+++ b/src/Fields/PreferredLanguages.php
@@ -6,8 +6,14 @@ namespace Spaze\SecurityTxt\Fields;
 use JsonSerializable;
 use Override;
 
-final readonly class PreferredLanguages implements JsonSerializable
+final readonly class PreferredLanguages implements SecurityTxtFieldValue, JsonSerializable
 {
+
+	/**
+	 * @internal
+	 */
+	public const string SEPARATOR = ',';
+
 
 	/**
 	 * @param list<string> $languages
@@ -15,6 +21,20 @@ final readonly class PreferredLanguages implements JsonSerializable
 	public function __construct(
 		private array $languages,
 	) {
+	}
+
+
+	#[Override]
+	public function getField(): SecurityTxtField
+	{
+		return SecurityTxtField::PreferredLanguages;
+	}
+
+
+	#[Override]
+	public function getValue(): string
+	{
+		return implode(self::SEPARATOR, $this->languages);
 	}
 
 

--- a/src/Fields/SecurityTxtFieldValue.php
+++ b/src/Fields/SecurityTxtFieldValue.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Fields;
+
+interface SecurityTxtFieldValue
+{
+
+	public function getField(): SecurityTxtField;
+
+
+	public function getValue(): string;
+
+}

--- a/src/Fields/SecurityTxtUriField.php
+++ b/src/Fields/SecurityTxtUriField.php
@@ -6,7 +6,7 @@ namespace Spaze\SecurityTxt\Fields;
 use JsonSerializable;
 use Override;
 
-abstract class SecurityTxtUriField implements JsonSerializable
+abstract class SecurityTxtUriField implements SecurityTxtFieldValue, JsonSerializable
 {
 
 	final public function __construct(
@@ -16,6 +16,13 @@ abstract class SecurityTxtUriField implements JsonSerializable
 
 
 	public function getUri(): string
+	{
+		return $this->uri;
+	}
+
+
+	#[Override]
+	public function getValue(): string
 	{
 		return $this->uri;
 	}

--- a/src/Parser/FieldProcessors/ExpiresSetFieldValue.php
+++ b/src/Parser/FieldProcessors/ExpiresSetFieldValue.php
@@ -24,7 +24,7 @@ final class ExpiresSetFieldValue implements FieldProcessor
 	#[Override]
 	public function process(string $value, SecurityTxt $securityTxt): void
 	{
-		$expiresValue = DateTimeImmutable::createFromFormat(DATE_RFC3339, $value);
+		$expiresValue = DateTimeImmutable::createFromFormat(Expires::FORMAT, $value);
 		if ($expiresValue === false) {
 			$expiresValue = DateTimeImmutable::createFromFormat(DATE_RFC3339_EXTENDED, $value);
 			if ($expiresValue === false) {

--- a/src/Parser/FieldProcessors/PreferredLanguagesSetFieldValue.php
+++ b/src/Parser/FieldProcessors/PreferredLanguagesSetFieldValue.php
@@ -25,7 +25,7 @@ final class PreferredLanguagesSetFieldValue implements FieldProcessor
 		if ($separators !== false && $separators > 0) {
 			$wrongSeparators = [];
 			foreach ($matches[1] as $key => $separator) {
-				if ($separator !== ',') {
+				if ($separator !== PreferredLanguages::SEPARATOR) {
 					$wrongSeparators[$key + 1] = $separator;
 				}
 			}

--- a/src/SecurityTxt.php
+++ b/src/SecurityTxt.php
@@ -38,6 +38,10 @@ use Spaze\SecurityTxt\Violations\SecurityTxtPreferredLanguagesWrongLanguageTags;
 final class SecurityTxt implements JsonSerializable
 {
 
+	public const string CONTENT_TYPE = 'text/plain';
+	public const string CHARSET = 'charset=utf-8';
+	public const string CONTENT_TYPE_HEADER = self::CONTENT_TYPE . '; ' . self::CHARSET;
+
 	private ?Expires $expires = null;
 	private ?SecurityTxtSignatureVerifyResult $signatureVerifyResult = null;
 	private ?PreferredLanguages $preferredLanguages = null;

--- a/src/SecurityTxt.php
+++ b/src/SecurityTxt.php
@@ -15,6 +15,7 @@ use Spaze\SecurityTxt\Fields\Expires;
 use Spaze\SecurityTxt\Fields\Hiring;
 use Spaze\SecurityTxt\Fields\Policy;
 use Spaze\SecurityTxt\Fields\PreferredLanguages;
+use Spaze\SecurityTxt\Fields\SecurityTxtFieldValue;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignatureVerifyResult;
 use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtAcknowledgmentsNotUri;
@@ -71,6 +72,11 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	private array $encryption = [];
 
+	/**
+	 * @var list<SecurityTxtFieldValue>
+	 */
+	private array $orderedFields = [];
+
 
 	public function __construct(
 		private readonly SecurityTxtValidationLevel $validationLevel = SecurityTxtValidationLevel::NoInvalidValues,
@@ -85,8 +91,8 @@ final class SecurityTxt implements JsonSerializable
 	public function setExpires(Expires $expires): void
 	{
 		$this->setValue(
-			function () use ($expires): void {
-				$this->expires = $expires;
+			function () use ($expires): Expires {
+				return $this->expires = $expires;
 			},
 			function () use ($expires): void {
 				if ($expires->isExpired()) {
@@ -126,8 +132,8 @@ final class SecurityTxt implements JsonSerializable
 	public function addCanonical(Canonical $canonical): void
 	{
 		$this->setValue(
-			function () use ($canonical): void {
-				$this->canonical[] = $canonical;
+			function () use ($canonical): Canonical {
+				return $this->canonical[] = $canonical;
 			},
 			function () use ($canonical): void {
 				$this->checkUri($canonical->getUri(), SecurityTxtCanonicalNotUri::class, SecurityTxtCanonicalNotHttps::class);
@@ -151,8 +157,8 @@ final class SecurityTxt implements JsonSerializable
 	public function addContact(Contact $contact): void
 	{
 		$this->setValue(
-			function () use ($contact): void {
-				$this->contact[] = $contact;
+			function () use ($contact): Contact {
+				return $this->contact[] = $contact;
 			},
 			function () use ($contact): void {
 				$this->checkUri($contact->getUri(), SecurityTxtContactNotUri::class, SecurityTxtContactNotHttps::class);
@@ -176,8 +182,8 @@ final class SecurityTxt implements JsonSerializable
 	public function setPreferredLanguages(PreferredLanguages $preferredLanguages): void
 	{
 		$this->setValue(
-			function () use ($preferredLanguages): void {
-				$this->preferredLanguages = $preferredLanguages;
+			function () use ($preferredLanguages): PreferredLanguages {
+				return $this->preferredLanguages = $preferredLanguages;
 			},
 			function () use ($preferredLanguages): void {
 				if ($preferredLanguages->getLanguages() === []) {
@@ -219,8 +225,8 @@ final class SecurityTxt implements JsonSerializable
 	public function addAcknowledgments(Acknowledgments $acknowledgments): void
 	{
 		$this->setValue(
-			function () use ($acknowledgments): void {
-				$this->acknowledgments[] = $acknowledgments;
+			function () use ($acknowledgments): Acknowledgments {
+				return $this->acknowledgments[] = $acknowledgments;
 			},
 			function () use ($acknowledgments): void {
 				$this->checkUri($acknowledgments->getUri(), SecurityTxtAcknowledgmentsNotUri::class, SecurityTxtAcknowledgmentsNotHttps::class);
@@ -244,8 +250,8 @@ final class SecurityTxt implements JsonSerializable
 	public function addHiring(Hiring $hiring): void
 	{
 		$this->setValue(
-			function () use ($hiring): void {
-				$this->hiring[] = $hiring;
+			function () use ($hiring): Hiring {
+				return $this->hiring[] = $hiring;
 			},
 			function () use ($hiring): void {
 				$this->checkUri($hiring->getUri(), SecurityTxtHiringNotUri::class, SecurityTxtHiringNotHttps::class);
@@ -269,8 +275,8 @@ final class SecurityTxt implements JsonSerializable
 	public function addPolicy(Policy $policy): void
 	{
 		$this->setValue(
-			function () use ($policy): void {
-				$this->policy[] = $policy;
+			function () use ($policy): Policy {
+				return $this->policy[] = $policy;
 			},
 			function () use ($policy): void {
 				$this->checkUri($policy->getUri(), SecurityTxtPolicyNotUri::class, SecurityTxtPolicyNotHttps::class);
@@ -294,8 +300,8 @@ final class SecurityTxt implements JsonSerializable
 	public function addEncryption(Encryption $encryption): void
 	{
 		$this->setValue(
-			function () use ($encryption): void {
-				$this->encryption[] = $encryption;
+			function () use ($encryption): Encryption {
+				return $this->encryption[] = $encryption;
 			},
 			function () use ($encryption): void {
 				$this->checkUri($encryption->getUri(), SecurityTxtEncryptionNotUri::class, SecurityTxtEncryptionNotHttps::class);
@@ -314,7 +320,7 @@ final class SecurityTxt implements JsonSerializable
 
 
 	/**
-	 * @param callable(): void $setValue
+	 * @param callable(): SecurityTxtFieldValue $setValue
 	 * @param callable(): void $validator
 	 * @param (callable(): void)|null $warnings
 	 * @return void
@@ -322,15 +328,15 @@ final class SecurityTxt implements JsonSerializable
 	private function setValue(callable $setValue, callable $validator, ?callable $warnings = null): void
 	{
 		if ($this->validationLevel === SecurityTxtValidationLevel::AllowInvalidValuesSilently) {
-			$setValue();
+			$this->orderedFields[] = $setValue();
 			return;
 		}
 		if ($this->validationLevel === SecurityTxtValidationLevel::AllowInvalidValues) {
-			$setValue();
+			$this->orderedFields[] = $setValue();
 			$validator();
 		} else {
 			$validator();
-			$setValue();
+			$this->orderedFields[] = $setValue();
 		}
 		if ($warnings !== null) {
 			$warnings();
@@ -352,6 +358,15 @@ final class SecurityTxt implements JsonSerializable
 		if (strtolower($scheme) === 'http') {
 			throw new SecurityTxtError(new $notHttpsError($uri));
 		}
+	}
+
+
+	/**
+	 * @return list<SecurityTxtFieldValue>
+	 */
+	public function getOrderedFields(): array
+	{
+		return $this->orderedFields;
 	}
 
 

--- a/src/Violations/SecurityTxtContentTypeInvalid.php
+++ b/src/Violations/SecurityTxtContentTypeInvalid.php
@@ -3,21 +3,27 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Violations;
 
+use Spaze\SecurityTxt\SecurityTxt;
+
 final class SecurityTxtContentTypeInvalid extends SecurityTxtSpecViolation
 {
 
 	public function __construct(string $url, ?string $contentType)
 	{
-		$format = $contentType !== null
-			? 'The file at `%s` has a `Content-Type` of `%s` but it should be a `Content-Type` of `text/plain` with the `charset` parameter set to `utf-8`'
-			: 'The file at `%s` has no `Content-Type` but it should be a `Content-Type` of `text/plain` with the `charset` parameter set to `utf-8`';
+		if ($contentType !== null) {
+			$format = 'The file at `%s` has a `Content-Type` of `%s` but it should be a `Content-Type` of `%s` with the `charset` parameter set to `%s`';
+			$values = [$url, $contentType, SecurityTxt::CONTENT_TYPE, SecurityTxt::CHARSET];
+		} else {
+			$format = 'The file at `%s` has no `Content-Type` but it should be a `Content-Type` of `%s` with the `charset` parameter set to `%s`';
+			$values = [$url, SecurityTxt::CONTENT_TYPE, SecurityTxt::CHARSET];
+		}
 		parent::__construct(
 			func_get_args(),
 			$format,
-			$contentType !== null ? [$url, $contentType] : [$url],
+			$values,
 			'draft-foudil-securitytxt-03',
-			'text/plain; charset=utf-8',
-			'Send a correct `Content-Type` header value of `text/plain` with the `charset` parameter set to `utf-8`',
+			SecurityTxt::CONTENT_TYPE_HEADER,
+			sprintf('Send a correct `Content-Type` header value of `%s` with the `charset` parameter set to `%s`', SecurityTxt::CONTENT_TYPE, SecurityTxt::CHARSET),
 			[],
 			'3',
 		);

--- a/src/Violations/SecurityTxtContentTypeWrongCharset.php
+++ b/src/Violations/SecurityTxtContentTypeWrongCharset.php
@@ -3,21 +3,23 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Violations;
 
+use Spaze\SecurityTxt\SecurityTxt;
+
 final class SecurityTxtContentTypeWrongCharset extends SecurityTxtSpecViolation
 {
 
 	public function __construct(string $url, string $contentType, ?string $charset)
 	{
 		$format = $charset !== null
-			? 'The file at `%s` has a correct `Content-Type` of `%s` but the `%s` parameter should be changed to `charset=utf-8`'
-			: 'The file at `%s` has a correct `Content-Type` of `%s` but the `charset=utf-8` parameter is missing';
+			? 'The file at `%s` has a correct `Content-Type` of `%s` but the `%s` parameter should be changed to `%s`'
+			: 'The file at `%s` has a correct `Content-Type` of `%s` but the `%s` parameter is missing';
 		parent::__construct(
 			func_get_args(),
 			$format,
-			$charset !== null ? [$url, $contentType, $charset] : [$url, $contentType],
+			$charset !== null ? [$url, $contentType, $charset, SecurityTxt::CHARSET] : [$url, $contentType, SecurityTxt::CHARSET],
 			'draft-foudil-securitytxt-03',
-			'text/plain; charset=utf-8',
-			$charset !== null ? 'Change the parameter to `charset=utf-8`' : 'Add a `charset=utf-8` parameter',
+			SecurityTxt::CONTENT_TYPE_HEADER,
+			sprintf($charset !== null ? 'Change the parameter to `%s`' : 'Add a `%s` parameter', SecurityTxt::CHARSET),
 			[],
 			'3',
 		);

--- a/src/Violations/SecurityTxtExpired.php
+++ b/src/Violations/SecurityTxtExpired.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\SecurityTxt\Violations;
 
 use DateTimeImmutable;
+use Spaze\SecurityTxt\Fields\Expires;
 
 final class SecurityTxtExpired extends SecurityTxtSpecViolation
 {
@@ -15,7 +16,7 @@ final class SecurityTxtExpired extends SecurityTxtSpecViolation
 			'The file is considered stale and should not be used',
 			[],
 			'draft-foudil-securitytxt-09',
-			new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339),
+			new DateTimeImmutable('+1 year midnight -1 sec')->format(Expires::FORMAT),
 			'The `Expires` field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
 			[],
 			'2.5.5',

--- a/src/Violations/SecurityTxtExpiresOldFormat.php
+++ b/src/Violations/SecurityTxtExpiresOldFormat.php
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 namespace Spaze\SecurityTxt\Violations;
 
 use DateTimeInterface;
+use Spaze\SecurityTxt\Fields\Expires;
 
 final class SecurityTxtExpiresOldFormat extends SecurityTxtSpecViolation
 {
 
 	public function __construct(DateTimeInterface $expires)
 	{
-		$correctValue = $expires->format(DATE_RFC3339);
+		$correctValue = $expires->format(Expires::FORMAT);
 		parent::__construct(
 			func_get_args(),
 			"The value of the `Expires` field follows the format defined in section 3.3 of RFC 5322 but it should be formatted according to the Internet profile of ISO 8601 as defined in RFC 3339",

--- a/src/Violations/SecurityTxtExpiresTooLong.php
+++ b/src/Violations/SecurityTxtExpiresTooLong.php
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 namespace Spaze\SecurityTxt\Violations;
 
 use DateTimeImmutable;
+use Spaze\SecurityTxt\Fields\Expires;
 
 final class SecurityTxtExpiresTooLong extends SecurityTxtSpecViolation
 {
 
 	public function __construct()
 	{
-		$correctValue = new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339);
+		$correctValue = new DateTimeImmutable('+1 year midnight -1 sec')->format(Expires::FORMAT);
 		parent::__construct(
 			func_get_args(),
 			'The value of the `Expires` should be less than a year into the future to avoid staleness',

--- a/src/Violations/SecurityTxtExpiresWrongFormat.php
+++ b/src/Violations/SecurityTxtExpiresWrongFormat.php
@@ -5,13 +5,14 @@ namespace Spaze\SecurityTxt\Violations;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Spaze\SecurityTxt\Fields\Expires;
 
 final class SecurityTxtExpiresWrongFormat extends SecurityTxtSpecViolation
 {
 
 	public function __construct(?DateTimeInterface $expires = null)
 	{
-		$correctValue = $expires !== null ? $expires->format(DATE_RFC3339) : new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339);
+		$correctValue = $expires !== null ? $expires->format(Expires::FORMAT) : new DateTimeImmutable('+1 year midnight -1 sec')->format(Expires::FORMAT);
 		parent::__construct(
 			func_get_args(),
 			'The format of the value of the `Expires` field is wrong',

--- a/src/Violations/SecurityTxtNoExpires.php
+++ b/src/Violations/SecurityTxtNoExpires.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\SecurityTxt\Violations;
 
 use DateTimeImmutable;
+use Spaze\SecurityTxt\Fields\Expires;
 
 final class SecurityTxtNoExpires extends SecurityTxtSpecViolation
 {
@@ -15,7 +16,7 @@ final class SecurityTxtNoExpires extends SecurityTxtSpecViolation
 			'The `Expires` field must always be present',
 			[],
 			'draft-foudil-securitytxt-10',
-			new DateTimeImmutable('+1 year midnight -1 sec')->format(DATE_RFC3339),
+			new DateTimeImmutable('+1 year midnight -1 sec')->format(Expires::FORMAT),
 			'Add an `Expires` field with a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339',
 			[],
 			'2.5.5',

--- a/src/Writer/SecurityTxtWriter.php
+++ b/src/Writer/SecurityTxtWriter.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Writer;
+
+use Spaze\SecurityTxt\SecurityTxt;
+
+final class SecurityTxtWriter
+{
+
+	public function write(SecurityTxt $securityTxt): string
+	{
+		$result = '';
+		foreach ($securityTxt->getOrderedFields() as $field) {
+			$result .= sprintf("%s: %s\n", $field->getField()->value, $field->getValue());
+		}
+		return $result;
+	}
+
+}

--- a/tests/Check/SecurityTxtCheckHostResultFactoryTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostResultFactoryTest.phpt
@@ -65,7 +65,7 @@ final class SecurityTxtCheckHostResultFactoryTest extends TestCase
 			'http://www.example.com/.well-known/security.txt',
 			'https://www.example.com/.well-known/security.txt',
 			['http://example.com' => ['https://example.com', 'https://www.example.com']],
-			"Hi-ring: https://example.com/hiring\nExpires: " . $dateTime->format(DATE_RFC3339),
+			"Hi-ring: https://example.com/hiring\nExpires: " . $dateTime->format(Expires::FORMAT),
 			[new SecurityTxtSchemeNotHttps('http://example.com')],
 			[new SecurityTxtWellKnownPathOnly()],
 		);

--- a/tests/Check/SecurityTxtCheckHostTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostTest.phpt
@@ -45,7 +45,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 			],
 			'constructedUrl' => 'http://www.example.com/.well-known/security.txt',
 			'finalUrl' => 'https://www.example.com/.well-known/security.txt',
-			'contents' => "Hi-ring: https://example.com/hiring\nExpires: " . $this->expires->format(DATE_RFC3339),
+			'contents' => "Hi-ring: https://example.com/hiring\nExpires: " . $this->expires->format(Expires::FORMAT),
 			'fetchResult' => [
 				'class' => 'Spaze\SecurityTxt\Fetcher\SecurityTxtFetchResult',
 				'constructedUrl' => 'http://www.example.com/.well-known/security.txt',
@@ -53,7 +53,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 				'redirects' => [
 					'http://example.com' => ['https://example.com', 'https://www.example.com'],
 				],
-				'contents' => "Hi-ring: https://example.com/hiring\nExpires: " . $this->expires->format(DATE_RFC3339),
+				'contents' => "Hi-ring: https://example.com/hiring\nExpires: " . $this->expires->format(Expires::FORMAT),
 				'errors' => [
 					[
 						'class' => 'Spaze\SecurityTxt\Violations\SecurityTxtSchemeNotHttps',
@@ -188,7 +188,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 				],
 			],
 			'securityTxt' => [
-				'expires' => ['dateTime' => $this->expires->format(DATE_RFC3339)],
+				'expires' => ['dateTime' => $this->expires->format(Expires::FORMAT)],
 				'signatureVerifyResult' => null,
 				'preferredLanguages' => null,
 				'canonical' => [],
@@ -219,7 +219,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 			'http://www.example.com/.well-known/security.txt',
 			'https://www.example.com/.well-known/security.txt',
 			['http://example.com' => ['https://example.com', 'https://www.example.com']],
-			"Hi-ring: https://example.com/hiring\nExpires: " . $this->expires->format(DATE_RFC3339),
+			"Hi-ring: https://example.com/hiring\nExpires: " . $this->expires->format(Expires::FORMAT),
 			[new SecurityTxtSchemeNotHttps('http://example.com')],
 			[new SecurityTxtWellKnownPathOnly()],
 		);

--- a/tests/Parser/FieldProcessors/ExpiresSetFieldValueTest.phpt
+++ b/tests/Parser/FieldProcessors/ExpiresSetFieldValueTest.phpt
@@ -6,6 +6,7 @@ namespace Spaze\SecurityTxt\Parser\FieldProcessors;
 
 use DateTimeImmutable;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
+use Spaze\SecurityTxt\Fields\Expires;
 use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\Violations\SecurityTxtExpiresOldFormat;
 use Spaze\SecurityTxt\Violations\SecurityTxtExpiresWrongFormat;
@@ -24,11 +25,11 @@ final class ExpiresSetFieldValueTest extends TestCase
 		$processor = new ExpiresSetFieldValue();
 		$expires = new DateTimeImmutable('+2 weeks');
 
-		$processor->process($expires->format(DATE_RFC3339), $securityTxt);
-		Assert::same($expires->format(DATE_RFC3339), $securityTxt->getExpires()?->getDateTime()->format(DATE_RFC3339));
+		$processor->process($expires->format(Expires::FORMAT), $securityTxt);
+		Assert::same($expires->format(Expires::FORMAT), $securityTxt->getExpires()?->getDateTime()->format(Expires::FORMAT));
 
 		$processor->process($expires->format(DATE_RFC3339_EXTENDED), $securityTxt);
-		Assert::same($expires->format(DATE_RFC3339), $securityTxt->getExpires()?->getDateTime()->format(DATE_RFC3339));
+		Assert::same($expires->format(Expires::FORMAT), $securityTxt->getExpires()?->getDateTime()->format(Expires::FORMAT));
 
 		$e = Assert::throws(function () use ($processor, $expires, $securityTxt): void {
 			$processor->process($expires->format(DATE_RFC2822), $securityTxt);

--- a/tests/Writer/SecurityTxtWriterTest.phpt
+++ b/tests/Writer/SecurityTxtWriterTest.phpt
@@ -1,0 +1,102 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Parser;
+
+use DateTimeImmutable;
+use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
+use Spaze\SecurityTxt\Fields\Acknowledgments;
+use Spaze\SecurityTxt\Fields\Contact;
+use Spaze\SecurityTxt\Fields\Expires;
+use Spaze\SecurityTxt\Fields\PreferredLanguages;
+use Spaze\SecurityTxt\SecurityTxt;
+use Spaze\SecurityTxt\SecurityTxtValidationLevel;
+use Spaze\SecurityTxt\Writer\SecurityTxtWriter;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class SecurityTxtWriterTest extends TestCase
+{
+
+	private SecurityTxtWriter $securityTxtWriter;
+
+
+	public function __construct()
+	{
+		$this->securityTxtWriter = new SecurityTxtWriter();
+	}
+
+
+	public function testWriteEmpty(): void
+	{
+		$securityTxt = new SecurityTxt();
+		Assert::same('', $this->securityTxtWriter->write($securityTxt));
+	}
+
+
+	public function testWrite(): void
+	{
+		$dateTime = new DateTimeImmutable('+3 months midnight');
+		$securityTxt = new SecurityTxt();
+		$securityTxt->addContact(new Contact('https://contact.example'));
+		$securityTxt->addContact(Contact::phone('123456'));
+		$securityTxt->addContact(Contact::email('email@com.example'));
+		$securityTxt->addAcknowledgments(new Acknowledgments('https://ack1.example'));
+		$securityTxt->setExpires(new Expires($dateTime));
+		$securityTxt->addAcknowledgments(new Acknowledgments('ftp://ack2.example'));
+		$securityTxt->setPreferredLanguages(new PreferredLanguages(['en', 'cs-CZ']));
+		$expected = "Contact: https://contact.example\n"
+			. "Contact: tel:123456\n"
+			. "Contact: mailto:email@com.example\n"
+			. "Acknowledgments: https://ack1.example\n"
+			. 'Expires: ' . $dateTime->format(DATE_RFC3339) . "\n"
+			. "Acknowledgments: ftp://ack2.example\n"
+			. "Preferred-Languages: en,cs-CZ\n";
+		Assert::same($expected, $this->securityTxtWriter->write($securityTxt));
+	}
+
+
+	public function testWriteDefaultValidationLevel(): void
+	{
+		$securityTxt = new SecurityTxt();
+		$securityTxt->addContact(new Contact('https://contact.example.com'));
+		Assert::throws(function () use ($securityTxt): void {
+			$securityTxt->addContact(new Contact('//no.scheme.example'));
+		}, SecurityTxtError::class, "The `Contact` value (`//no.scheme.example`) doesn't follow the URI syntax described in RFC 3986, the scheme is missing");
+		Assert::same("Contact: https://contact.example.com\n", $this->securityTxtWriter->write($securityTxt));
+
+		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::NoInvalidValues);
+		$securityTxt->addContact(new Contact('https://contact.example.com'));
+		Assert::throws(function () use ($securityTxt): void {
+			$securityTxt->addContact(new Contact('//no.scheme.example'));
+		}, SecurityTxtError::class, "The `Contact` value (`//no.scheme.example`) doesn't follow the URI syntax described in RFC 3986, the scheme is missing");
+		Assert::same("Contact: https://contact.example.com\n", $this->securityTxtWriter->write($securityTxt));
+	}
+
+
+	public function testWriteAllowInvalidValues(): void
+	{
+		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::AllowInvalidValues);
+		$securityTxt->addContact(new Contact('https://contact.example.com'));
+		Assert::throws(function () use ($securityTxt): void {
+			$securityTxt->addContact(new Contact('//no.scheme.example'));
+		}, SecurityTxtError::class, "The `Contact` value (`//no.scheme.example`) doesn't follow the URI syntax described in RFC 3986, the scheme is missing");
+		Assert::same("Contact: https://contact.example.com\nContact: //no.scheme.example\n", $this->securityTxtWriter->write($securityTxt));
+	}
+
+
+	public function testWriteAllowInvalidValuesSilently(): void
+	{
+		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::AllowInvalidValuesSilently);
+		$securityTxt->addContact(new Contact('https://contact.example.com'));
+		$securityTxt->addContact(new Contact('//no.scheme.example'));
+		Assert::same("Contact: https://contact.example.com\nContact: //no.scheme.example\n", $this->securityTxtWriter->write($securityTxt));
+	}
+
+}
+
+new SecurityTxtWriterTest()->run();


### PR DESCRIPTION
An example:
```php
$securityTxt = new SecurityTxt();
$securityTxt->addContact(new Contact('https://contact.example'));
$securityTxt->addContact(Contact::phone('123456'));
$securityTxt->addContact(Contact::email('email@com.example'));
$securityTxt->addAcknowledgments(new Acknowledgments('https://ack1.example'));
$securityTxt->setExpires(new Expires(new DateTimeImmutable('+3 months midnight')));
$securityTxt->addAcknowledgments(new Acknowledgments('ftp://ack2.example'));
$securityTxt->setPreferredLanguages(new PreferredLanguages(['en', 'cs-CZ']));
header('Content-Type: ' . SecurityTxt::CONTENT_TYPE_HEADER);
echo new SecurityTxtWriter()->write($securityTxt);
```
