### PR TITLE
Move the throws tags to the interface

### DIFF
--- a/src/Signature/Providers/SecurityTxtSignatureGnuPgProvider.php
+++ b/src/Signature/Providers/SecurityTxtSignatureGnuPgProvider.php
@@ -23,9 +23,6 @@ final class SecurityTxtSignatureGnuPgProvider implements SecurityTxtSignaturePro
 	}
 
 
-	/**
-	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
-	 */
 	#[Override]
 	public function addSignKey(string $fingerprint, #[SensitiveParameter] string $passphrase = ''): bool
 	{
@@ -33,9 +30,6 @@ final class SecurityTxtSignatureGnuPgProvider implements SecurityTxtSignaturePro
 	}
 
 
-	/**
-	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
-	 */
 	#[Override]
 	public function getErrorInfo(): SecurityTxtSignatureErrorInfo
 	{
@@ -49,9 +43,6 @@ final class SecurityTxtSignatureGnuPgProvider implements SecurityTxtSignaturePro
 	}
 
 
-	/**
-	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
-	 */
 	#[Override]
 	public function sign(string $text): false|string
 	{
@@ -59,11 +50,6 @@ final class SecurityTxtSignatureGnuPgProvider implements SecurityTxtSignaturePro
 	}
 
 
-	/**
-	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
-	 * @throws SecurityTxtInvalidSignatureException
-	 * @throws SecurityTxtCannotVerifySignatureException
-	 */
 	#[Override]
 	public function verify(string $text): SecurityTxtSignatureVerifySignatureInfo
 	{

--- a/src/Signature/Providers/SecurityTxtSignatureProvider.php
+++ b/src/Signature/Providers/SecurityTxtSignatureProvider.php
@@ -4,21 +4,38 @@ declare(strict_types = 1);
 namespace Spaze\SecurityTxt\Signature\Providers;
 
 use SensitiveParameter;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtCannotCreateSignatureExtensionNotLoadedException;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtCannotVerifySignatureException;
+use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtInvalidSignatureException;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignatureErrorInfo;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignatureVerifySignatureInfo;
 
 interface SecurityTxtSignatureProvider
 {
 
+	/**
+	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
+	 */
 	public function addSignKey(string $fingerprint, #[SensitiveParameter] string $passphrase = ''): bool;
 
 
+	/**
+	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
+	 */
 	public function getErrorInfo(): SecurityTxtSignatureErrorInfo;
 
 
+	/**
+	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
+	 */
 	public function sign(string $text): false|string;
 
 
+	/**
+	 * @throws SecurityTxtCannotCreateSignatureExtensionNotLoadedException
+	 * @throws SecurityTxtInvalidSignatureException
+	 * @throws SecurityTxtCannotVerifySignatureException
+	 */
 	public function verify(string $text): SecurityTxtSignatureVerifySignatureInfo;
 
 }

--- a/src/Signature/SecurityTxtSignature.php
+++ b/src/Signature/SecurityTxtSignature.php
@@ -15,7 +15,6 @@ use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtSigningKeyBadPassphraseExc
 use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtSigningKeyNoPassphraseSetException;
 use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtUnknownSigningKeyException;
 use Spaze\SecurityTxt\Signature\Exceptions\SecurityTxtUnusableSigningKeyException;
-use Spaze\SecurityTxt\Signature\Providers\SecurityTxtSignatureGnuPgProvider;
 use Spaze\SecurityTxt\Signature\Providers\SecurityTxtSignatureProvider;
 use Spaze\SecurityTxt\Violations\SecurityTxtSignatureExtensionNotLoaded;
 use Spaze\SecurityTxt\Violations\SecurityTxtSignatureInvalid;
@@ -31,9 +30,8 @@ final class SecurityTxtSignature
 	private array $addedSignKeys = [];
 
 
-	public function __construct(
-		private SecurityTxtSignatureProvider|SecurityTxtSignatureGnuPgProvider $signatureProvider,
-	) {
+	public function __construct(private SecurityTxtSignatureProvider $signatureProvider)
+	{
 	}
 
 


### PR DESCRIPTION
So I can remove the union type in `SecurityTxtSignature`

Follow-up to #31 #32