### PR TITLE
Revert "Specify that the gnupg ext needs to build libgpgme first"

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,8 +42,6 @@ jobs:
         coverage: none
         php-version: ${{ matrix.php-version }}
         extensions: gnupg
-      env:
-        GNUPG_LIBS: libgpgme-dev
     - name: Validate composer.json
       run: composer validate --strict --no-interaction
     - name: Install dependencies
@@ -72,8 +70,6 @@ jobs:
         coverage: none
         php-version: ${{ matrix.php-version }}
         extensions: gnupg
-      env:
-        GNUPG_LIBS: libgpgme-dev
     - name: Validate composer.json
       run: composer validate --strict --no-interaction
     - name: Install dependencies


### PR DESCRIPTION
This reverts commit 0bbfd7f95dabc21285a4e470ed324608542ad320 of #35.

> ...installing gnupg from source would install the required libgpgme library automatically.
https://github.com/shivammathur/setup-php/releases/tag/2.36.0