### PR TITLE
Validate the `Canonical` field

### DIFF
--- a/src/Fetcher/SecurityTxtFetcher.php
+++ b/src/Fetcher/SecurityTxtFetcher.php
@@ -20,7 +20,6 @@ use Spaze\SecurityTxt\Parser\SecurityTxtUrlParser;
 use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\Violations\SecurityTxtContentTypeInvalid;
 use Spaze\SecurityTxt\Violations\SecurityTxtContentTypeWrongCharset;
-use Spaze\SecurityTxt\Violations\SecurityTxtSchemeNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtTopLevelDiffers;
 use Spaze\SecurityTxt\Violations\SecurityTxtTopLevelPathOnly;
 use Spaze\SecurityTxt\Violations\SecurityTxtWellKnownPathOnly;
@@ -218,10 +217,6 @@ final class SecurityTxtFetcher
 			$errors[] = new SecurityTxtContentTypeInvalid($result->getUrl(), $contentTypeHeader?->getContentType());
 		} elseif ($contentTypeHeader->getLowercaseCharset() !== SecurityTxt::CHARSET) {
 			$errors[] = new SecurityTxtContentTypeWrongCharset($result->getUrl(), $contentTypeHeader->getContentType(), $contentTypeHeader->getCharset());
-		}
-		$scheme = parse_url($result->getUrl(), PHP_URL_SCHEME);
-		if ($scheme !== 'https') {
-			$errors[] = new SecurityTxtSchemeNotHttps($result->getUrl());
 		}
 		return new SecurityTxtFetchResult(
 			$result->getUrl(),

--- a/src/Json/SecurityTxtJson.php
+++ b/src/Json/SecurityTxtJson.php
@@ -96,6 +96,12 @@ final readonly class SecurityTxtJson
 	{
 		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::AllowInvalidValuesSilently);
 		try {
+			if (isset($values['fileLocation'])) {
+				if (!is_string($values['fileLocation'])) {
+					throw new SecurityTxtCannotParseJsonException('fileLocation is not a string');
+				}
+				$securityTxt->setFileLocation($values['fileLocation']);
+			}
 			if (isset($values['expires'])) {
 				if (!is_array($values['expires'])) {
 					throw new SecurityTxtCannotParseJsonException('expires is not an array');

--- a/src/Parser/SecurityTxtParser.php
+++ b/src/Parser/SecurityTxtParser.php
@@ -112,7 +112,7 @@ final class SecurityTxtParser
 	/**
 	 * @throws SecurityTxtCannotVerifySignatureException
 	 */
-	public function parseString(string $contents, ?int $expiresWarningThreshold = null, bool $strictMode = false): SecurityTxtParseStringResult
+	public function parseString(string $contents, ?string $fileLocation = null, ?int $expiresWarningThreshold = null, bool $strictMode = false): SecurityTxtParseStringResult
 	{
 		$this->expiresWarningThreshold = $expiresWarningThreshold;
 		$this->initFieldProcessors();
@@ -125,6 +125,9 @@ final class SecurityTxtParser
 			SecurityTxtField::cases(),
 		);
 		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::AllowInvalidValues);
+		if ($fileLocation !== null) {
+			$securityTxt->setFileLocation($fileLocation);
+		}
 		for ($lineNumber = 1; $lineNumber <= count($lines); $lineNumber++) {
 			$line = trim($lines[$lineNumber - 1]);
 			if (!str_ends_with($lines[$lineNumber - 1], "\n")) {
@@ -170,7 +173,7 @@ final class SecurityTxtParser
 	 */
 	public function parseFetchResult(SecurityTxtFetchResult $fetchResult, ?int $expiresWarningThreshold = null, bool $strictMode = false): SecurityTxtParseHostResult
 	{
-		$parseResult = $this->parseString($fetchResult->getContents(), $expiresWarningThreshold, $strictMode);
+		$parseResult = $this->parseString($fetchResult->getContents(), $fetchResult->getFinalUrl(), $expiresWarningThreshold, $strictMode);
 		return new SecurityTxtParseHostResult(
 			$parseResult->isValid() && $fetchResult->getErrors() === [] && (!$strictMode || $fetchResult->getWarnings() === []),
 			$parseResult,

--- a/src/SecurityTxt.php
+++ b/src/SecurityTxt.php
@@ -27,6 +27,8 @@ use Spaze\SecurityTxt\Violations\SecurityTxtEncryptionNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtEncryptionNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtExpired;
 use Spaze\SecurityTxt\Violations\SecurityTxtExpiresTooLong;
+use Spaze\SecurityTxt\Violations\SecurityTxtFileLocationNotHttps;
+use Spaze\SecurityTxt\Violations\SecurityTxtFileLocationNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtHiringNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtHiringNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtPolicyNotHttps;
@@ -42,6 +44,7 @@ final class SecurityTxt implements JsonSerializable
 	public const string CHARSET = 'charset=utf-8';
 	public const string CONTENT_TYPE_HEADER = self::CONTENT_TYPE . '; ' . self::CHARSET;
 
+	private ?string $fileLocation = null;
 	private ?SecurityTxtExpires $expires = null;
 	private ?SecurityTxtSignatureVerifyResult $signatureVerifyResult = null;
 	private ?SecurityTxtPreferredLanguages $preferredLanguages = null;
@@ -88,13 +91,32 @@ final class SecurityTxt implements JsonSerializable
 	}
 
 
+	public function setFileLocation(string $fileLocation): void
+	{
+		$this->setValue(
+			function () use ($fileLocation): void {
+				$this->fileLocation = $fileLocation;
+			},
+			function () use ($fileLocation): void {
+				$this->checkUri($fileLocation, SecurityTxtFileLocationNotUri::class, SecurityTxtFileLocationNotHttps::class);
+			},
+		);
+	}
+
+
+	public function getFileLocation(): ?string
+	{
+		return $this->fileLocation;
+	}
+
+
 	/**
 	 * @throws SecurityTxtError
 	 * @throws SecurityTxtWarning
 	 */
 	public function setExpires(SecurityTxtExpires $expires): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($expires): SecurityTxtExpires {
 				return $this->expires = $expires;
 			},
@@ -137,7 +159,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function addCanonical(SecurityTxtCanonical $canonical): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($canonical): SecurityTxtCanonical {
 				return $this->canonical[] = $canonical;
 			},
@@ -162,7 +184,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function addContact(SecurityTxtContact $contact): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($contact): SecurityTxtContact {
 				return $this->contact[] = $contact;
 			},
@@ -187,7 +209,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function setPreferredLanguages(SecurityTxtPreferredLanguages $preferredLanguages): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($preferredLanguages): SecurityTxtPreferredLanguages {
 				return $this->preferredLanguages = $preferredLanguages;
 			},
@@ -231,7 +253,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function addAcknowledgments(SecurityTxtAcknowledgments $acknowledgments): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($acknowledgments): SecurityTxtAcknowledgments {
 				return $this->acknowledgments[] = $acknowledgments;
 			},
@@ -256,7 +278,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function addHiring(SecurityTxtHiring $hiring): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($hiring): SecurityTxtHiring {
 				return $this->hiring[] = $hiring;
 			},
@@ -281,7 +303,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function addPolicy(SecurityTxtPolicy $policy): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($policy): SecurityTxtPolicy {
 				return $this->policy[] = $policy;
 			},
@@ -306,7 +328,7 @@ final class SecurityTxt implements JsonSerializable
 	 */
 	public function addEncryption(SecurityTxtEncryption $encryption): void
 	{
-		$this->setValue(
+		$this->setFieldValue(
 			function () use ($encryption): SecurityTxtEncryption {
 				return $this->encryption[] = $encryption;
 			},
@@ -327,24 +349,40 @@ final class SecurityTxt implements JsonSerializable
 
 
 	/**
+	 * @param callable(): void $setValue
+	 * @param callable(): void $validator
+	 * @return void
+	 */
+	private function setValue(callable $setValue, callable $validator): void
+	{
+		if ($this->validationLevel === SecurityTxtValidationLevel::AllowInvalidValuesSilently) {
+			$setValue();
+			return;
+		}
+		if ($this->validationLevel === SecurityTxtValidationLevel::AllowInvalidValues) {
+			$setValue();
+			$validator();
+		} else {
+			$validator();
+			$setValue();
+		}
+	}
+
+
+	/**
 	 * @param callable(): SecurityTxtFieldValue $setValue
 	 * @param callable(): void $validator
 	 * @param (callable(): void)|null $warnings
 	 * @return void
 	 */
-	private function setValue(callable $setValue, callable $validator, ?callable $warnings = null): void
+	private function setFieldValue(callable $setValue, callable $validator, ?callable $warnings = null): void
 	{
-		if ($this->validationLevel === SecurityTxtValidationLevel::AllowInvalidValuesSilently) {
-			$this->orderedFields[] = $setValue();
-			return;
-		}
-		if ($this->validationLevel === SecurityTxtValidationLevel::AllowInvalidValues) {
-			$this->orderedFields[] = $setValue();
-			$validator();
-		} else {
-			$validator();
-			$this->orderedFields[] = $setValue();
-		}
+		$this->setValue(
+			function () use ($setValue): void {
+				$this->orderedFields[] = $setValue();
+			},
+			$validator,
+		);
 		if ($warnings !== null) {
 			$warnings();
 		}
@@ -352,8 +390,8 @@ final class SecurityTxt implements JsonSerializable
 
 
 	/**
-	 * @param class-string<SecurityTxtAcknowledgmentsNotUri|SecurityTxtCanonicalNotUri|SecurityTxtContactNotUri|SecurityTxtEncryptionNotUri|SecurityTxtHiringNotUri|SecurityTxtPolicyNotUri> $notUriError
-	 * @param class-string<SecurityTxtAcknowledgmentsNotHttps|SecurityTxtCanonicalNotHttps|SecurityTxtContactNotHttps|SecurityTxtEncryptionNotHttps|SecurityTxtHiringNotHttps|SecurityTxtPolicyNotHttps> $notHttpsError
+	 * @param class-string<SecurityTxtAcknowledgmentsNotUri|SecurityTxtCanonicalNotUri|SecurityTxtContactNotUri|SecurityTxtEncryptionNotUri|SecurityTxtHiringNotUri|SecurityTxtPolicyNotUri|SecurityTxtFileLocationNotUri> $notUriError
+	 * @param class-string<SecurityTxtAcknowledgmentsNotHttps|SecurityTxtCanonicalNotHttps|SecurityTxtContactNotHttps|SecurityTxtEncryptionNotHttps|SecurityTxtHiringNotHttps|SecurityTxtPolicyNotHttps|SecurityTxtFileLocationNotHttps> $notHttpsError
 	 * @throws SecurityTxtError
 	 */
 	private function checkUri(string $uri, string $notUriError, string $notHttpsError): void
@@ -384,6 +422,7 @@ final class SecurityTxt implements JsonSerializable
 	public function jsonSerialize(): array
 	{
 		return [
+			'fileLocation' => $this->getFileLocation(),
 			'expires' => $this->getExpires(),
 			'signatureVerifyResult' => $this->getSignatureVerifyResult(),
 			'preferredLanguages' => $this->getPreferredLanguages(),

--- a/src/Validator/SecurityTxtValidator.php
+++ b/src/Validator/SecurityTxtValidator.php
@@ -6,6 +6,7 @@ namespace Spaze\SecurityTxt\Validator;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtWarning;
 use Spaze\SecurityTxt\SecurityTxt;
+use Spaze\SecurityTxt\Validator\Validators\CanonicalUriListedFieldValidator;
 use Spaze\SecurityTxt\Validator\Validators\ContactMissingFieldValidator;
 use Spaze\SecurityTxt\Validator\Validators\ExpiresMissingFieldValidator;
 use Spaze\SecurityTxt\Validator\Validators\FieldValidator;
@@ -23,6 +24,7 @@ final class SecurityTxtValidator
 	public function __construct()
 	{
 		$this->fieldValidators = [
+			new CanonicalUriListedFieldValidator(),
 			new ContactMissingFieldValidator(),
 			new ExpiresMissingFieldValidator(),
 			new SignedButCanonicalMissingFieldValidator(),

--- a/src/Validator/Validators/CanonicalUriListedFieldValidator.php
+++ b/src/Validator/Validators/CanonicalUriListedFieldValidator.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Validator\Validators;
+
+use Override;
+use Spaze\SecurityTxt\Exceptions\SecurityTxtWarning;
+use Spaze\SecurityTxt\SecurityTxt;
+use Spaze\SecurityTxt\Violations\SecurityTxtCanonicalUriMismatch;
+
+final class CanonicalUriListedFieldValidator implements FieldValidator
+{
+
+	#[Override]
+	public function validate(SecurityTxt $securityTxt): void
+	{
+		$uri = $securityTxt->getFileLocation();
+		if ($uri === null) {
+			return;
+		}
+
+		$canonicals = $securityTxt->getCanonical();
+		if ($canonicals === []) {
+			return;
+		}
+
+		$canonicalUris = array_map(fn($canonical) => $canonical->getUri(), $canonicals);
+		if (!in_array($uri, $canonicalUris, true)) {
+			throw new SecurityTxtWarning(new SecurityTxtCanonicalUriMismatch($uri, $canonicalUris));
+		}
+	}
+
+}

--- a/src/Violations/SecurityTxtCanonicalUriMismatch.php
+++ b/src/Violations/SecurityTxtCanonicalUriMismatch.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Violations;
+
+use Spaze\SecurityTxt\Fields\SecurityTxtField;
+
+final class SecurityTxtCanonicalUriMismatch extends SecurityTxtSpecViolation
+{
+
+	/**
+	 * @param list<string> $canonicalUris
+	 */
+	public function __construct(string $uri, array $canonicalUris)
+	{
+		$count = count($canonicalUris);
+		if ($count === 1) {
+			$messageFormat = 'The file was fetched from %s but the %s field (%s) does not list this URI';
+			$howToFixFormat = 'Add a new %s field with the URI %s, or ensure the file is fetched from the listed canonical URI';
+		} else {
+			$fields = implode(', ', array_fill(0, $count, '%s'));
+			$messageFormat = 'The file was fetched from %s but none of the %s fields (' . $fields . ') list this URI';
+			$howToFixFormat = 'Add a new %s field with the URI %s, or ensure the file is fetched from one of the listed canonical URIs';
+		}
+		parent::__construct(
+			func_get_args(),
+			$messageFormat,
+			[$uri, SecurityTxtField::Canonical->value, ...$canonicalUris],
+			'draft-foudil-securitytxt-05',
+			null,
+			$howToFixFormat,
+			[SecurityTxtField::Canonical->value, $uri],
+			'2.5.2',
+		);
+	}
+
+}

--- a/src/Violations/SecurityTxtFileLocationNotHttps.php
+++ b/src/Violations/SecurityTxtFileLocationNotHttps.php
@@ -3,17 +3,17 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Violations;
 
-final class SecurityTxtSchemeNotHttps extends SecurityTxtSpecViolation
+final class SecurityTxtFileLocationNotHttps extends SecurityTxtSpecViolation
 {
 
-	public function __construct(string $url)
+	public function __construct(string $uri)
 	{
 		parent::__construct(
 			func_get_args(),
 			"The file at %s must use HTTPS",
-			[$url],
+			[$uri],
 			'draft-foudil-securitytxt-06',
-			preg_replace('~^http://~', 'https://', $url),
+			preg_replace('~^http://~', 'https://', $uri),
 			'Use HTTPS to serve the %s file',
 			['security.txt'],
 			'3',

--- a/src/Violations/SecurityTxtFileLocationNotUri.php
+++ b/src/Violations/SecurityTxtFileLocationNotUri.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Violations;
+
+final class SecurityTxtFileLocationNotUri extends SecurityTxtSpecViolation
+{
+
+	public function __construct(string $uri)
+	{
+		parent::__construct(
+			func_get_args(),
+			"The location of the file %s doesn't follow the URI syntax described in RFC 3986, the scheme is missing",
+			[$uri],
+			'draft-foudil-securitytxt-00',
+			null,
+			'Use a URI as the value',
+			[],
+			'3',
+		);
+	}
+
+}

--- a/tests/Check/SecurityTxtCheckHostResultFactoryTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostResultFactoryTest.phpt
@@ -47,7 +47,7 @@ final class SecurityTxtCheckHostResultFactoryTest extends TestCase
 			"Expires: 2020-10-15T00:01:02+02:00\n",
 		];
 		$contents = implode('', $lines);
-		$parseStringResult = $this->parser->parseString($contents, 123, true);
+		$parseStringResult = $this->parser->parseString($contents, null, 123, true);
 		$fetchResult = new SecurityTxtFetchResult(
 			'https://com.example/.well-known/security.txt',
 			'https://com.example/.well-known/security.txt',

--- a/tests/Check/SecurityTxtCheckHostTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostTest.phpt
@@ -11,10 +11,10 @@ use Spaze\SecurityTxt\Fields\SecurityTxtExpires;
 use Spaze\SecurityTxt\Fields\SecurityTxtExpiresFactory;
 use Spaze\SecurityTxt\Fields\SecurityTxtField;
 use Spaze\SecurityTxt\SecurityTxt;
+use Spaze\SecurityTxt\Violations\SecurityTxtFileLocationNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtLineNoEol;
 use Spaze\SecurityTxt\Violations\SecurityTxtNoContact;
 use Spaze\SecurityTxt\Violations\SecurityTxtPossibelFieldTypo;
-use Spaze\SecurityTxt\Violations\SecurityTxtSchemeNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtSignatureExtensionNotLoaded;
 use Spaze\SecurityTxt\Violations\SecurityTxtWellKnownPathOnly;
 use Tester\Assert;
@@ -54,7 +54,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 				'isTruncated' => true,
 				'errors' => [
 					[
-						'class' => 'Spaze\SecurityTxt\Violations\SecurityTxtSchemeNotHttps',
+						'class' => 'Spaze\SecurityTxt\Violations\SecurityTxtFileLocationNotHttps',
 						'params' => ['http://example.com'],
 						'message' => 'The file at http://example.com must use HTTPS',
 						'messageFormat' => 'The file at %s must use HTTPS',
@@ -87,7 +87,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 			],
 			'fetchErrors' => [
 				[
-					'class' => SecurityTxtSchemeNotHttps::class,
+					'class' => SecurityTxtFileLocationNotHttps::class,
 					'params' => ['http://example.com'],
 					'message' => 'The file at http://example.com must use HTTPS',
 					'messageFormat' => 'The file at %s must use HTTPS',
@@ -186,6 +186,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 				],
 			],
 			'securityTxt' => [
+				'fileLocation' => 'https://foo.example/.well-known/security.txt',
 				'expires' => [
 					'dateTime' => $this->expires->format(SecurityTxtExpires::FORMAT),
 					'isExpired' => false,
@@ -215,6 +216,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 	private function getResult(): SecurityTxtCheckHostResult
 	{
 		$securityTxt = new SecurityTxt();
+		$securityTxt->setFileLocation('https://foo.example/.well-known/security.txt');
 		$securityTxt->setExpires($this->expiresFactory->create($this->expires));
 		$lines = ["Hi-ring: https://example.com/hiring\n", 'Expires: ' . $this->expires->format(SecurityTxtExpires::FORMAT)];
 		$fetchResult = new SecurityTxtFetchResult(
@@ -224,7 +226,7 @@ final class SecurityTxtCheckHostTest extends TestCase
 			implode($lines),
 			true,
 			$lines,
-			[new SecurityTxtSchemeNotHttps('http://example.com')],
+			[new SecurityTxtFileLocationNotHttps('http://example.com')],
 			[new SecurityTxtWellKnownPathOnly()],
 		);
 		return new SecurityTxtCheckHostResult(

--- a/tests/SecurityTxtTest.phpt
+++ b/tests/SecurityTxtTest.phpt
@@ -18,6 +18,8 @@ use Spaze\SecurityTxt\Violations\SecurityTxtContactNotHttps;
 use Spaze\SecurityTxt\Violations\SecurityTxtContactNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtExpired;
 use Spaze\SecurityTxt\Violations\SecurityTxtExpiresTooLong;
+use Spaze\SecurityTxt\Violations\SecurityTxtFileLocationNotHttps;
+use Spaze\SecurityTxt\Violations\SecurityTxtFileLocationNotUri;
 use Spaze\SecurityTxt\Violations\SecurityTxtPreferredLanguagesCommonMistake;
 use Spaze\SecurityTxt\Violations\SecurityTxtPreferredLanguagesEmpty;
 use Spaze\SecurityTxt\Violations\SecurityTxtPreferredLanguagesWrongLanguageTags;
@@ -37,6 +39,27 @@ final class SecurityTxtTest extends TestCase
 	public function __construct()
 	{
 		$this->securityTxtExpiresFactory = new SecurityTxtExpiresFactory();
+	}
+
+
+	public function testSetFileLocation(): void
+	{
+		$securityTxt = new SecurityTxt();
+		$securityTxt->setExpires($this->securityTxtExpiresFactory->create(new DateTimeImmutable('+2 weeks')));
+		$securityTxt->setFileLocation('https://foo/bar');
+		Assert::same('https://foo/bar', $securityTxt->getFileLocation());
+
+		$e = Assert::throws(function () use ($securityTxt): void {
+			$securityTxt->setFileLocation('http://foo/bar');
+		}, SecurityTxtError::class);
+		assert($e instanceof SecurityTxtError);
+		Assert::type(SecurityTxtFileLocationNotHttps::class, $e->getViolation());
+
+		$e = Assert::throws(function () use ($securityTxt): void {
+			$securityTxt->setFileLocation('foo');
+		}, SecurityTxtError::class);
+		assert($e instanceof SecurityTxtError);
+		Assert::type(SecurityTxtFileLocationNotUri::class, $e->getViolation());
 	}
 
 


### PR DESCRIPTION
> If this field appears within a "security.txt" file and the URI used to retrieve that file is not listed within any canonical fields, then the contents of the file SHOULD NOT be trusted.

https://www.rfc-editor.org/rfc/rfc9116#name-canonical

Close #40