### PR TITLE
Unknown field now generates a warning

### DIFF
--- a/src/Violations/SecurityTxtUnknownField.php
+++ b/src/Violations/SecurityTxtUnknownField.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Violations;
+
+final class SecurityTxtUnknownField extends SecurityTxtSpecViolation
+{
+
+	public function __construct(string $fieldName, string $line)
+	{
+		parent::__construct(
+			func_get_args(),
+			'Field %s is unknown',
+			[$fieldName],
+			null,
+			"# {$line}",
+			"Remove the line or comment it out",
+			[],
+			null,
+		);
+	}
+
+}


### PR DESCRIPTION
If the file is signed with GPG, then the `Hash:` header and all other [_Armor Headers_](https://www.rfc-editor.org/rfc/rfc4880#section-7) of the OpenPGP format up until a separator (an empty line) are not flagged as unknown fields.

Close #41