### PR TITLE
Inline the content type constants

### DIFF
--- a/src/SecurityTxtContentType.php
+++ b/src/SecurityTxtContentType.php
@@ -8,7 +8,7 @@ final readonly class SecurityTxtContentType
 
 	public const string CONTENT_TYPE = 'text/plain';
 	public const string CHARSET = 'utf-8';
-	public const string CHARSET_PARAMETER = 'charset=' . self::CHARSET;
-	public const string MEDIA_TYPE = self::CONTENT_TYPE . '; ' . self::CHARSET_PARAMETER;
+	public const string CHARSET_PARAMETER = 'charset=utf-8';
+	public const string MEDIA_TYPE = 'text/plain; charset=utf-8';
 
 }


### PR DESCRIPTION
It's not like these would change, ever. Also helps in IDEs when they show the constant value on hover for example, then you'd like to see the actual value, not what it's concatenated of.

Follow-up to #47