### PR TITLE
Max length configurable and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ You can set it in `SecurityTxtFetcherCurlClient` constructor (the `$userAgent` p
 ## Maximum file size
 The size of the file is limited when fetching the contents from remote hosts. By default, the limit is 10 000 bytes, but you can change it in `SecurityTxtFetcherCurlClient` constructor (the `$maxResponseLength` parameter). Then, when creating `SecurityTxtFetcher`, pass that customized client as its HTTP client argument together with the other constructor arguments required by `SecurityTxtFetcher`.
 
+## DNS lookups
+DNS resolution is handled by `SecurityTxtPhpDnsProvider`, which uses PHP's built-in `dns_get_record()`. This function has no timeout parameter, the system DNS timeout applies.
+If you need explicit DNS timeout control, or would like to use for example DNS-over-HTTPS, you can add a custom provider, which implements the `SecurityTxtDnsProvider` interface,
+and then pass it to `SecurityTxtFetcher` in the `$dnsLookupProvider` parameter.
+
 ## JSON
 The `Spaze\SecurityTxt\Check\SecurityTxtCheckHostResult` object can be encoded to JSON with `json_encode()`,
 and decoded back with `Spaze\SecurityTxt\Json\SecurityTxtJson::createCheckHostResultFromJsonValues()`.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ DNS resolution is handled by `SecurityTxtPhpDnsProvider`, which uses PHP's built
 If you need explicit DNS timeout control, or would like to use for example DNS-over-HTTPS, you can add a custom provider, which implements the `SecurityTxtDnsProvider` interface,
 and then pass it to `SecurityTxtFetcher` in the `$dnsLookupProvider` parameter.
 
+## Signature verification
+This library verifies that the signature is a valid OpenPGP cleartext signature, but cannot verify whether the signing key is trustworthy, for example when the key is not in local keyring etc. As the [`security.txt` RFC](https://www.rfc-editor.org/rfc/rfc9116#name-digital-signature) puts it:
+"it is always the security researcher's responsibility to make sure the key being used is indeed one they trust." Verify the key fingerprint or key id out-of-band, for example by checking it against the company's website or other trusted sources.
+
 ## JSON
 The `Spaze\SecurityTxt\Check\SecurityTxtCheckHostResult` object can be encoded to JSON with `json_encode()`,
 and decoded back with `Spaze\SecurityTxt\Json\SecurityTxtJson::createCheckHostResultFromJsonValues()`.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Returns `list<SecurityTxtSpecViolation>`, the list contains file-level warnings 
 ## Callbacks
 `SecurityTxtCheckHost::check()` supports callbacks that can be set with `SecurityTxtCheckHost::addOn*()` methods. You can use them to get the parsing information in "real time", and are used for example by the `bin/checksecuritytxt.php` script via the `\Spaze\SecurityTxt\Check\SecurityTxtCheckHostCli` class to print information as soon as it is available.
 
+## User agent
+When fetching the `security.txt` file, the library uses a default `User-Agent` HTTP header. The default value contains a link back to the GitHub repository, but it is recommended you use a custom `User-Agent` header.
+You can set it in `SecurityTxtFetcherCurlClient` constructor (the `$userAgent` parameter), and then pass the client object to `SecurityTxtFetcher` constructor as one of its arguments.
+
+## Maximum file size
+The size of the file is limited when fetching the contents from remote hosts. By default, the limit is 10 000 bytes, but you can change it in `SecurityTxtFetcherCurlClient` constructor (the `$maxResponseLength` parameter). Then, when creating `SecurityTxtFetcher`, pass that customized client as its HTTP client argument together with the other constructor arguments required by `SecurityTxtFetcher`.
+
 ## JSON
 The `Spaze\SecurityTxt\Check\SecurityTxtCheckHostResult` object can be encoded to JSON with `json_encode()`,
 and decoded back with `Spaze\SecurityTxt\Json\SecurityTxtJson::createCheckHostResultFromJsonValues()`.

--- a/src/Fetcher/HttpClients/SecurityTxtFetcherCurlClient.php
+++ b/src/Fetcher/HttpClients/SecurityTxtFetcherCurlClient.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\SecurityTxt\Fetcher\HttpClients;
 
 use CurlHandle;
+use LogicException;
 use Override;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotOpenUrlException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotOpenUrlExtensionNotLoadedException;
@@ -17,13 +18,13 @@ use Spaze\SecurityTxt\Fetcher\SecurityTxtIpAddressType;
 final readonly class SecurityTxtFetcherCurlClient implements SecurityTxtFetcherHttpClient
 {
 
-	private const int MAX_RESPONSE_LENGTH = 10_000;
-	private const string DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; spaze/security-txt; +https://github.com/spaze/security-txt)';
-
-
 	public function __construct(
-		private string $userAgent = self::DEFAULT_USER_AGENT,
+		private string $userAgent = 'Mozilla/5.0 (compatible; spaze/security-txt; +https://github.com/spaze/security-txt)',
+		private int $maxResponseLength = 10_000,
 	) {
+		if ($this->maxResponseLength <= 0) {
+			throw new LogicException('maxResponseLength must be greater than 0');
+		}
 	}
 
 
@@ -76,7 +77,7 @@ final readonly class SecurityTxtFetcherCurlClient implements SecurityTxtFetcherH
 			},
 			CURLOPT_WRITEFUNCTION => function (CurlHandle $ch, string $data) use (&$contents, &$truncated): int {
 				$length = strlen($data);
-				$remaining = self::MAX_RESPONSE_LENGTH - strlen($contents);
+				$remaining = $this->maxResponseLength - strlen($contents);
 				// Returning 0 stops transfer, but also throws CURLE_WRITE_ERROR, which we'll have to discard
 				if ($remaining <= 0) {
 					$truncated = true;

--- a/tests/Fetcher/HttpClients/SecurityTxtFetcherCurlClientTest.phpt
+++ b/tests/Fetcher/HttpClients/SecurityTxtFetcherCurlClientTest.phpt
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Fetcher;
 
+use LogicException;
 use Spaze\SecurityTxt\Fetcher\DnsLookup\SecurityTxtPhpDnsProvider;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotOpenUrlException;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtCannotOpenUrlUserAgentInvalidException;
@@ -74,6 +75,28 @@ final class SecurityTxtFetcherCurlClientTest extends TestCase
 	}
 
 
+	public function testGetResponseMaxResponseLengthSetting(): void
+	{
+		needsInternet();
+		$client = new SecurityTxtFetcherCurlClient(maxResponseLength: 100_000);
+		$url = new Url('https://httpbin.org/bytes/31337');
+		$ipAddress = $this->dnsProvider->getRecords($url, 'httpbin.org')->getIpRecord();
+		if ($ipAddress === null) {
+			Assert::fail("Can't find an IP address for httpbin.org");
+		} else {
+			$response = $client->getResponse(
+				new SecurityTxtFetcherUrl($url, []),
+				'httpbin.org',
+				$ipAddress,
+				SecurityTxtIpAddressType::V4,
+			);
+			Assert::same(200, $response->getHttpCode());
+			Assert::false($response->isTruncated());
+			Assert::true(strlen($response->getContents()) > 10_000);
+		}
+	}
+
+
 	public function testGetResponseSettingHost(): void
 	{
 		needsInternet();
@@ -117,6 +140,17 @@ final class SecurityTxtFetcherCurlClientTest extends TestCase
 		Assert::throws(function () use ($client): void {
 			$client->getResponse(new SecurityTxtFetcherUrl(new Url('https://com.example/'), []), 'com.example', '1.1.1.0', SecurityTxtIpAddressType::V4);
 		}, SecurityTxtCannotOpenUrlUserAgentInvalidException::class, "Can't open https://com.example/, the specified user agent contains a control character and is invalid");
+	}
+
+
+	public function testMaxResponseLengthPositive(): void
+	{
+		Assert::throws(function (): void {
+			new SecurityTxtFetcherCurlClient(maxResponseLength: 0);
+		}, LogicException::class, 'maxResponseLength must be greater than 0');
+		Assert::throws(function (): void {
+			new SecurityTxtFetcherCurlClient(maxResponseLength: -1);
+		}, LogicException::class, 'maxResponseLength must be greater than 0');
 	}
 
 }


### PR DESCRIPTION
Make the maxlength when fetching configurable

Docs update:
- Document the cURL client parameters (user agent, max length)
- Document DNS lookups and timeouts
- Document that the the trustworthiness of the key used to sign the file cannot be verified, meaning that `GNUPG_SIGSUM_KEY_MISSING` is fine