### PR TITLE
Add UTF-8 body content validation

### DIFF
--- a/src/Parser/SecurityTxtParser.php
+++ b/src/Parser/SecurityTxtParser.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\SecurityTxt\Parser;
 
+use LogicException;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtError;
 use Spaze\SecurityTxt\Exceptions\SecurityTxtWarning;
 use Spaze\SecurityTxt\Fetcher\SecurityTxtFetchResult;
@@ -28,7 +29,9 @@ use Spaze\SecurityTxt\Parser\SplitProviders\SecurityTxtSplitProvider;
 use Spaze\SecurityTxt\SecurityTxt;
 use Spaze\SecurityTxt\SecurityTxtValidationLevel;
 use Spaze\SecurityTxt\Signature\SecurityTxtSignature;
+use Spaze\SecurityTxt\Validator\SecurityTxtValidateResult;
 use Spaze\SecurityTxt\Validator\SecurityTxtValidator;
+use Spaze\SecurityTxt\Violations\SecurityTxtContentNotUtf8;
 use Spaze\SecurityTxt\Violations\SecurityTxtLineNoEol;
 use Spaze\SecurityTxt\Violations\SecurityTxtPossibelFieldTypo;
 use Spaze\SecurityTxt\Violations\SecurityTxtSpecViolation;
@@ -126,6 +129,25 @@ final class SecurityTxtParser
 		$this->expiresWarningThreshold = $expiresWarningThreshold;
 		$this->initFieldProcessors();
 		$this->lineErrors = $this->lineWarnings = [];
+		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::AllowInvalidValues);
+		if ($fileLocation !== null) {
+			$securityTxt->setFileLocation($fileLocation);
+		}
+		if (@preg_match('//u', $contents) === false) { // Intentionally silenced
+			$pregError = preg_last_error();
+			if ($pregError !== PREG_BAD_UTF8_ERROR) {
+				throw new LogicException('preg_match() failed with PCRE error code ' . $pregError);
+			}
+			return new SecurityTxtParseStringResult(
+				$securityTxt,
+				false,
+				$strictMode,
+				$this->expiresWarningThreshold,
+				$this->lineErrors,
+				$this->lineWarnings,
+				new SecurityTxtValidateResult([new SecurityTxtContentNotUtf8()], []),
+			);
+		}
 		$lines = $this->splitLines->splitLines($contents);
 		$securityTxtFields = array_combine(
 			array_map(function (SecurityTxtField $securityTxtField): string {
@@ -133,10 +155,6 @@ final class SecurityTxtParser
 			}, SecurityTxtField::cases()),
 			SecurityTxtField::cases(),
 		);
-		$securityTxt = new SecurityTxt(SecurityTxtValidationLevel::AllowInvalidValues);
-		if ($fileLocation !== null) {
-			$securityTxt->setFileLocation($fileLocation);
-		}
 		for ($lineNumber = 1; $lineNumber <= count($lines); $lineNumber++) {
 			$line = trim($lines[$lineNumber - 1]);
 			if (!str_ends_with($lines[$lineNumber - 1], "\n")) {

--- a/src/Violations/SecurityTxtContentNotUtf8.php
+++ b/src/Violations/SecurityTxtContentNotUtf8.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SecurityTxt\Violations;
+
+use Spaze\SecurityTxt\SecurityTxtContentType;
+
+final class SecurityTxtContentNotUtf8 extends SecurityTxtSpecViolation
+{
+
+	public function __construct()
+	{
+		$utf8 = strtoupper(SecurityTxtContentType::CHARSET);
+		parent::__construct(
+			func_get_args(),
+			'The file content is not encoded in %s',
+			[$utf8],
+			'draft-foudil-securitytxt-00',
+			null,
+			'Re-encode the file in %s',
+			[$utf8],
+			'4',
+		);
+	}
+
+}

--- a/tests/Parser/SecurityTxtParserTest.phpt
+++ b/tests/Parser/SecurityTxtParserTest.phpt
@@ -24,6 +24,7 @@ use Spaze\SecurityTxt\Validator\SecurityTxtValidator;
 use Spaze\SecurityTxt\Violations\SecurityTxtBugBountyWrongCase;
 use Spaze\SecurityTxt\Violations\SecurityTxtBugBountyWrongValue;
 use Spaze\SecurityTxt\Violations\SecurityTxtContactNotHttps;
+use Spaze\SecurityTxt\Violations\SecurityTxtContentNotUtf8;
 use Spaze\SecurityTxt\Violations\SecurityTxtContentTypeInvalid;
 use Spaze\SecurityTxt\Violations\SecurityTxtContentTypeWrongCharset;
 use Spaze\SecurityTxt\Violations\SecurityTxtCsafNotHttps;
@@ -276,6 +277,21 @@ final class SecurityTxtParserTest extends TestCase
 		Assert::type(SecurityTxtNoContact::class, $contactError);
 		Assert::true($parseResult->hasErrors());
 		Assert::false($parseResult->hasWarnings());
+	}
+
+
+	public function testParseStringContentNotUtf8(): void
+	{
+		$parseResult = $this->securityTxtParser->parseString("\xFF\xFE");
+		$errors = $parseResult->getFileErrors();
+		Assert::count(1, $errors);
+		Assert::type(SecurityTxtContentNotUtf8::class, $errors[0]);
+		Assert::same([], $parseResult->getFileWarnings());
+		Assert::same([], $parseResult->getLineErrors());
+		Assert::same([], $parseResult->getLineWarnings());
+		Assert::true($parseResult->hasErrors());
+		Assert::false($parseResult->hasWarnings());
+		Assert::false($parseResult->isValid());
 	}
 
 


### PR DESCRIPTION
The content validation has to run before any other validation to reject non-UTF-8 early enough. `preg_match()`'s `u` flag is used instead of `mb_check_encoding()` to avoid adding the `mbstring` extension as a dependency.