### PR TITLE
Simplify the console color output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ All errors and warnings are `SecurityTxtSpecViolation` subclasses in `src/Violat
 
 Tests use [Nette Tester](https://tester.nette.org/) (`.phpt` files). Each test file is a standalone PHP script ending with `(new FooTest())->run()`. The `tests/bootstrap.php` sets up the autoloader and provides a `needsInternet()` helper that skips network-dependent tests unless `TEST_CASE_RUNNER_INCLUDE_SKIPPED=1`.
 
+When an assertion fails, Tester writes the full actual and expected values to `tests/*/output/FooTest.actual` and `tests/*/output/FooTest.expected` and prints a `diff` command to compare them — use that instead of reading the truncated terminal output. These files are regenerated on every run; do not edit them.
+
+Inline heredoc expected strings in `.phpt` files contain **raw ANSI escape characters** (not `\033[` literals). Text editors and the Edit tool show them as plain `[1;32m` etc., but the bytes are real ESC (0x1b) sequences. Replacing them requires handling the actual bytes — use Python with `ESC = '\033'` and string concatenation rather than text substitution.
+
 ### Constraints
 
 - `parse_url()` is banned — use `Uri\WhatWg\Url` (PHP 8.5 built-in, WhatWG URL standard). Enforced by PHPStan via `phpstan.neon`.

--- a/src/Check/ConsolePrinter.php
+++ b/src/Check/ConsolePrinter.php
@@ -18,6 +18,12 @@ final class ConsolePrinter
 	}
 
 
+	public function ok(string $message): void
+	{
+		$this->print($this->colorGreen('[OK]'), $message);
+	}
+
+
 	public function info(string $message): void
 	{
 		$this->print($this->colorDarkGray('[Info]'), $message);

--- a/src/Check/SecurityTxtCheckHostCli.php
+++ b/src/Check/SecurityTxtCheckHostCli.php
@@ -52,7 +52,7 @@ final readonly class SecurityTxtCheckHostCli
 		);
 		$this->checkHost->addOnFinalUrl(
 			function (string $url): void {
-				$this->consolePrinter->info('Selecting security.txt located at ' . $this->consolePrinter->colorBold($url) . ' for further tests');
+				$this->consolePrinter->info('Using ' . $this->consolePrinter->colorBold($url));
 			},
 		);
 		$this->checkHost->addOnRedirect(
@@ -72,7 +72,7 @@ final readonly class SecurityTxtCheckHostCli
 		);
 		$this->checkHost->addOnExpires(
 			function (int $inDays, DateTimeImmutable $expiryDate): void {
-				$this->consolePrinter->info($this->consolePrinter->colorGreen("The file will expire in {$inDays} " . ($inDays === 1 ? 'day' : 'days')) . " ({$expiryDate->format(DATE_RFC3339)})");
+				$this->consolePrinter->ok("The file will expire in {$inDays} " . ($inDays === 1 ? 'day' : 'days') . " ({$expiryDate->format(DATE_RFC3339)})");
 			},
 		);
 		$this->checkHost->addOnHost(
@@ -82,9 +82,8 @@ final readonly class SecurityTxtCheckHostCli
 		);
 		$this->checkHost->addOnValidSignature(
 			function (string $keyFingerprint, DateTimeImmutable $signatureDate): void {
-				$this->consolePrinter->info(sprintf(
-					'%s, key %s, signed on %s',
-					$this->consolePrinter->colorGreen('Signature valid'),
+				$this->consolePrinter->ok(sprintf(
+					'Signature valid, key %s, signed on %s',
 					$keyFingerprint,
 					$signatureDate->format(DATE_RFC3339),
 				));
@@ -126,9 +125,10 @@ final readonly class SecurityTxtCheckHostCli
 				$noIpv6,
 			);
 			if (!$checkResult->isValid()) {
-				$this->consolePrinter->error($this->consolePrinter->colorRed('Please update the file!'));
+				$this->consolePrinter->error($this->consolePrinter->colorRed('The file is invalid'));
 				$this->exit(CheckExitStatus::Error);
 			} else {
+				$this->consolePrinter->ok($this->consolePrinter->colorGreen('The file is valid'));
 				$this->exit(CheckExitStatus::Ok);
 			}
 		} catch (SecurityTxtFetcherException $e) {

--- a/tests/Check/ConsolePrinterTest.phpt
+++ b/tests/Check/ConsolePrinterTest.phpt
@@ -14,31 +14,48 @@ require __DIR__ . '/../bootstrap.php';
 final class ConsolePrinterTest extends TestCase
 {
 
-	private ConsolePrinter $printer;
-
-
-	public function __construct()
+	public function testPrinterColorsOn(): void
 	{
-		$this->printer = new ConsolePrinter();
-	}
-
-
-	public function testPrinter(): void
-	{
-		$this->printer->enableColors();
+		$printer = new ConsolePrinter();
+		$printer->enableColors();
 		ob_start();
-		$this->printer->info('Never');
-		$this->printer->error('gonna');
-		$this->printer->warning('give');
-		$this->printer->info($this->printer->colorGreen('you'));
-		$this->printer->info($this->printer->colorBold('up'));
+		$printer->ok('🕺');
+		$printer->info('Never');
+		$printer->error('gonna');
+		$printer->warning('give');
+		$printer->info($printer->colorGreen('you'));
+		$printer->info($printer->colorBold('up'));
 		$output = ob_get_clean();
 		$expected = <<< EOT
+		[1;32m[OK][0m 🕺
 		[1;90m[Info][0m Never
 		[1;31m[Error][0m gonna
 		[1m[Warning][0m give
 		[1;90m[Info][0m [1;32myou[0m
 		[1;90m[Info][0m [1mup[0m
+		EOT;
+		Assert::same($expected . "\n", $output);
+	}
+
+
+	public function testPrinterColorsOff(): void
+	{
+		$printer = new ConsolePrinter();
+		ob_start();
+		$printer->ok('🕺');
+		$printer->info('Never');
+		$printer->error('gonna');
+		$printer->warning('give');
+		$printer->info($printer->colorGreen('you'));
+		$printer->info($printer->colorBold('up'));
+		$output = ob_get_clean();
+		$expected = <<< EOT
+		[OK] 🕺
+		[Info] Never
+		[Error] gonna
+		[Warning] give
+		[Info] you
+		[Info] up
 		EOT;
 		Assert::same($expected . "\n", $output);
 	}

--- a/tests/Check/SecurityTxtCheckHostCliTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostCliTest.phpt
@@ -62,12 +62,12 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		[1;90m[Info][0m Loading security.txt from [1mhttps://example.com/security.txt[0m
 		[1;90m[Info][0m Redirected from [1mhttps://example.com/security.txt[0m to [1mhttps://nah.example/[0m
 		[1;90m[Info][0m Not found [1mhttps://nah.example/[0m
-		[1;90m[Info][0m Selecting security.txt located at [1mhttps://example.com/.well-known/security.txt[0m for further tests
+		[1;90m[Info][0m Using [1mhttps://example.com/.well-known/security.txt[0m
 		[1;31m[Error][0m The file at https://example.com/.well-known/security.txt has a correct Content-Type of text/plain but the charset=utf-8 parameter is missing (How to fix: Add a charset=utf-8 parameter, e.g. text/plain; charset=utf-8)
 		[1;31m[Error][0m on line [1m2[0m: The file is considered stale and should not be used (How to fix: The Expires field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339, e.g. {$this->getExpiresExample()})
 		[1m[Warning][0m security.txt not found at the top-level path (How to fix: Redirect the top-level file to the one under the /.well-known/ path)
 		[1;31m[Error][0m [1;31mThe file has expired 42 days ago[0m ({$this->expires})
-		[1;31m[Error][0m [1;31mPlease update the file![0m
+		[1;31m[Error][0m [1;31mThe file is invalid[0m
 		EOT;
 		Assert::same($expected . "\n", $output);
 		Assert::same(CheckExitStatus::Error->value, $this->exitStatus);
@@ -93,10 +93,10 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		[1;90m[Info][0m Loading security.txt from [1mhttps://example.com/.well-known/security.txt[0m
 		[1;90m[Info][0m Loading security.txt from [1mhttps://example.com/security.txt[0m
 		[1;90m[Info][0m Not found [1mhttps://example.com/security.txt[0m
-		[1;90m[Info][0m Selecting security.txt located at [1mhttps://example.com/.well-known/security.txt[0m for further tests
+		[1;90m[Info][0m Using [1mhttps://example.com/.well-known/security.txt[0m
 		[1m[Warning][0m on line [1m2[0m: The file will be considered stale in 5 days (How to fix: Update the value of the Expires field, e.g. {$this->getExpiresExample()})
-		[1;90m[Info][0m [1;32mThe file will expire in 5 days[0m ({$expires})
-		[1;31m[Error][0m [1;31mPlease update the file![0m
+		[1;32m[OK][0m The file will expire in 5 days ({$expires})
+		[1;31m[Error][0m [1;31mThe file is invalid[0m
 		EOT;
 		Assert::same($expected . "\n", $output);
 		Assert::same(CheckExitStatus::Error->value, $this->exitStatus);
@@ -137,9 +137,10 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		[1;90m[Info][0m Loading security.txt from [1mhttps://example.com/.well-known/security.txt[0m
 		[1;90m[Info][0m Loading security.txt from [1mhttps://example.com/security.txt[0m
 		[1;90m[Info][0m Not found [1mhttps://example.com/security.txt[0m
-		[1;90m[Info][0m Selecting security.txt located at [1mhttps://example.com/.well-known/security.txt[0m for further tests
-		[1;90m[Info][0m [1;32mThe file will expire in 5 days[0m ({$expires})
-		[1;90m[Info][0m [1;32mSignature valid[0m, key AF6E1775E311FF78E911E7DC7F879001A9C8F50A, signed on 2025-07-22T02:10:07+00:00
+		[1;90m[Info][0m Using [1mhttps://example.com/.well-known/security.txt[0m
+		[1;32m[OK][0m The file will expire in 5 days ({$expires})
+		[1;32m[OK][0m Signature valid, key AF6E1775E311FF78E911E7DC7F879001A9C8F50A, signed on 2025-07-22T02:10:07+00:00
+		[1;32m[OK][0m [1;32mThe file is valid[0m
 		EOT;
 		Assert::same($expected . "\n", $output);
 		Assert::same(CheckExitStatus::Ok->value, $this->exitStatus);


### PR DESCRIPTION
The `[OK]` string is always green, but the text following it isn't, unless it's the last line "The file is invalid"/"The file is valid" which is always full-color (red for error, green for ok).