### PR TITLE
Add `--verbose` to `checksecuritytxt.php`

### DIFF
--- a/bin/checksecuritytxt.php
+++ b/bin/checksecuritytxt.php
@@ -63,12 +63,14 @@ $checkHostCli->check(
 	$url,
 	isset($args[2]) && $args[2] !== '' ? (int)$args[2] : null,
 	in_array('--colors', $args, true),
+	in_array('--verbose', $args, true),
 	in_array('--strict', $args, true),
 	in_array('--require-top-level-location', $args, true),
 	in_array('--no-ipv6', $args, true),
 	in_array('--help', $args, true) || in_array('-h', $args, true),
-	'Usage: ' . basename(__FILE__) . " <URL or hostname> [days] [--colors] [--strict] [--require-top-level-location] [--no-ipv6] [-h|--help]\n"
+	'Usage: ' . basename(__FILE__) . " <URL or hostname> [days] [--colors] [--verbose] [--strict] [--require-top-level-location] [--no-ipv6] [-h|--help]\n"
 		. "If <days> is specified, and if the file expires in less than <days>, the script will print a warning.\n"
+		. "When --verbose is specified, additional details such as loaded URLs and redirects are printed.\n"
 		. "When --require-top-level-location is specified, the /security.txt location must also exist or be redirected, otherwise a warning will be issued.\n"
 		. "The check will return 1 instead of 0 if any of the following conditions are true: the file has expired, has errors, or has warnings when using --strict.",
 );

--- a/src/Check/SecurityTxtCheckHost.php
+++ b/src/Check/SecurityTxtCheckHost.php
@@ -75,6 +75,7 @@ final class SecurityTxtCheckHost
 		private readonly SecurityTxtFetcher $fetcher,
 		private readonly SecurityTxtCheckHostResultFactory $resultFactory,
 	) {
+		$this->initFetcherCallbacks();
 	}
 
 
@@ -99,8 +100,6 @@ final class SecurityTxtCheckHost
 	 */
 	public function check(Url $url, ?int $expiresWarningThreshold = null, bool $strictMode = false, bool $requireTopLevelLocation = false, bool $noIpv6 = false, ?int $maxAllowedRedirects = null): SecurityTxtCheckHostResult
 	{
-		$this->initFetcherCallbacks();
-
 		$host = $url->getUnicodeHost();
 		if ($host === null) {
 			throw new SecurityTxtCannotParseHostnameException($url->toUnicodeString());

--- a/src/Check/SecurityTxtCheckHostCli.php
+++ b/src/Check/SecurityTxtCheckHostCli.php
@@ -8,17 +8,21 @@ use DateTimeImmutable;
 use Spaze\SecurityTxt\Fetcher\Exceptions\SecurityTxtFetcherException;
 use Uri\WhatWg\Url;
 
-final readonly class SecurityTxtCheckHostCli
+final class SecurityTxtCheckHostCli
 {
+
+	private bool $verbose = false;
+
 
 	/**
 	 * @param Closure(int): void $exit
 	 */
 	public function __construct(
-		private ConsolePrinter $consolePrinter,
-		private SecurityTxtCheckHost $checkHost,
-		private Closure $exit,
+		private readonly ConsolePrinter $consolePrinter,
+		private readonly SecurityTxtCheckHost $checkHost,
+		private readonly Closure $exit,
 	) {
+		$this->initCheckHostCallbacks();
 	}
 
 
@@ -33,6 +37,7 @@ final readonly class SecurityTxtCheckHostCli
 		bool $showUsageHelp,
 		string $usageHelp,
 	): void {
+		$this->verbose = $verbose;
 		if ($colors) {
 			$this->consolePrinter->enableColors();
 		}
@@ -45,24 +50,57 @@ final readonly class SecurityTxtCheckHostCli
 			$this->exit(CheckExitStatus::NoFile);
 			return;
 		}
-
-		if ($verbose) {
-			$this->checkHost->addOnUrl(
-				function (string $url): void {
-					$this->consolePrinter->info('Loading security.txt from ' . $this->consolePrinter->colorBold($url));
-				},
+		try {
+			$checkResult = $this->checkHost->check(
+				$url,
+				$expiresWarningThreshold,
+				$strictMode,
+				$requireTopLevelLocation,
+				$noIpv6,
 			);
-			$this->checkHost->addOnRedirect(
-				function (string $url, string $destination): void {
-					$this->consolePrinter->info('Redirected from ' . $this->consolePrinter->colorBold($url) . ' to ' . $this->consolePrinter->colorBold($destination));
-				},
-			);
-			$this->checkHost->addOnUrlNotFound(
-				function (string $url): void {
-					$this->consolePrinter->info('Not found ' . $this->consolePrinter->colorBold($url));
-				},
-			);
+			if (!$checkResult->isValid()) {
+				$this->consolePrinter->error($this->consolePrinter->colorRed('The file is invalid'));
+				$this->exit(CheckExitStatus::Error);
+			} else {
+				$this->consolePrinter->ok($this->consolePrinter->colorGreen('The file is valid'));
+				$this->exit(CheckExitStatus::Ok);
+			}
+		} catch (SecurityTxtFetcherException $e) {
+			$this->consolePrinter->error($e->getMessage());
+			$this->exit(CheckExitStatus::FileError);
 		}
+	}
+
+
+	private function exit(CheckExitStatus $exitStatus): void
+	{
+		($this->exit)($exitStatus->value);
+	}
+
+
+	private function initCheckHostCallbacks(): void
+	{
+		$this->checkHost->addOnUrl(
+			function (string $url): void {
+				if ($this->verbose) {
+					$this->consolePrinter->info('Loading security.txt from ' . $this->consolePrinter->colorBold($url));
+				}
+			},
+		);
+		$this->checkHost->addOnRedirect(
+			function (string $url, string $destination): void {
+				if ($this->verbose) {
+					$this->consolePrinter->info('Redirected from ' . $this->consolePrinter->colorBold($url) . ' to ' . $this->consolePrinter->colorBold($destination));
+				}
+			},
+		);
+		$this->checkHost->addOnUrlNotFound(
+			function (string $url): void {
+				if ($this->verbose) {
+					$this->consolePrinter->info('Not found ' . $this->consolePrinter->colorBold($url));
+				}
+			},
+		);
 		$this->checkHost->addOnFinalUrl(
 			function (string $url): void {
 				$this->consolePrinter->info('Using ' . $this->consolePrinter->colorBold($url));
@@ -118,32 +156,6 @@ final readonly class SecurityTxtCheckHostCli
 		$this->checkHost->addOnFetchWarning($onWarning);
 		$this->checkHost->addOnLineWarning($onWarning);
 		$this->checkHost->addOnFileWarning($onWarning);
-
-		try {
-			$checkResult = $this->checkHost->check(
-				$url,
-				$expiresWarningThreshold,
-				$strictMode,
-				$requireTopLevelLocation,
-				$noIpv6,
-			);
-			if (!$checkResult->isValid()) {
-				$this->consolePrinter->error($this->consolePrinter->colorRed('The file is invalid'));
-				$this->exit(CheckExitStatus::Error);
-			} else {
-				$this->consolePrinter->ok($this->consolePrinter->colorGreen('The file is valid'));
-				$this->exit(CheckExitStatus::Ok);
-			}
-		} catch (SecurityTxtFetcherException $e) {
-			$this->consolePrinter->error($e->getMessage());
-			$this->exit(CheckExitStatus::FileError);
-		}
-	}
-
-
-	private function exit(CheckExitStatus $exitStatus): void
-	{
-		($this->exit)($exitStatus->value);
 	}
 
 }

--- a/src/Check/SecurityTxtCheckHostCli.php
+++ b/src/Check/SecurityTxtCheckHostCli.php
@@ -26,6 +26,7 @@ final readonly class SecurityTxtCheckHostCli
 		?Url $url,
 		?int $expiresWarningThreshold,
 		bool $colors,
+		bool $verbose,
 		bool $strictMode,
 		bool $requireTopLevelLocation,
 		bool $noIpv6,
@@ -45,24 +46,26 @@ final readonly class SecurityTxtCheckHostCli
 			return;
 		}
 
-		$this->checkHost->addOnUrl(
-			function (string $url): void {
-				$this->consolePrinter->info('Loading security.txt from ' . $this->consolePrinter->colorBold($url));
-			},
-		);
+		if ($verbose) {
+			$this->checkHost->addOnUrl(
+				function (string $url): void {
+					$this->consolePrinter->info('Loading security.txt from ' . $this->consolePrinter->colorBold($url));
+				},
+			);
+			$this->checkHost->addOnRedirect(
+				function (string $url, string $destination): void {
+					$this->consolePrinter->info('Redirected from ' . $this->consolePrinter->colorBold($url) . ' to ' . $this->consolePrinter->colorBold($destination));
+				},
+			);
+			$this->checkHost->addOnUrlNotFound(
+				function (string $url): void {
+					$this->consolePrinter->info('Not found ' . $this->consolePrinter->colorBold($url));
+				},
+			);
+		}
 		$this->checkHost->addOnFinalUrl(
 			function (string $url): void {
 				$this->consolePrinter->info('Using ' . $this->consolePrinter->colorBold($url));
-			},
-		);
-		$this->checkHost->addOnRedirect(
-			function (string $url, string $destination): void {
-				$this->consolePrinter->info('Redirected from ' . $this->consolePrinter->colorBold($url) . ' to ' . $this->consolePrinter->colorBold($destination));
-			},
-		);
-		$this->checkHost->addOnUrlNotFound(
-			function (string $url): void {
-				$this->consolePrinter->info('Not found ' . $this->consolePrinter->colorBold($url));
 			},
 		);
 		$this->checkHost->addOnIsExpired(

--- a/tests/Check/SecurityTxtCheckHostCliTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostCliTest.phpt
@@ -54,7 +54,7 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(new Url('https://example.com'), null, true, true, true, true, false, 'Help I need some<body>');
+		$checkHostCli->check(new Url('https://example.com'), null, true, true, true, true, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		$expected = <<< EOT
 		[1;90m[Info][0m Parsing security.txt for [1mexample.com[0m
@@ -64,6 +64,32 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		[1;90m[Info][0m Not found [1mhttps://nah.example/[0m
 		[1;90m[Info][0m Using [1mhttps://example.com/.well-known/security.txt[0m
 		[1;31m[Error][0m The file at https://example.com/.well-known/security.txt has a correct Content-Type of text/plain but the charset=utf-8 parameter is missing (How to fix: Add a charset=utf-8 parameter, e.g. text/plain; charset=utf-8)
+		[1;31m[Error][0m on line [1m2[0m: The file is considered stale and should not be used (How to fix: The Expires field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339, e.g. {$this->getExpiresExample()})
+		[1m[Warning][0m security.txt not found at the top-level path (How to fix: Redirect the top-level file to the one under the /.well-known/ path)
+		[1;31m[Error][0m [1;31mThe file has expired 42 days ago[0m ({$this->expires})
+		[1;31m[Error][0m [1;31mThe file is invalid[0m
+		EOT;
+		Assert::same($expected . "\n", $output);
+		Assert::same(CheckExitStatus::Error->value, $this->exitStatus);
+	}
+
+
+	public function testCheckErrorWarningNonVerbose(): void
+	{
+		$contents = "Contact: mailto:foo@example.com\nExpires: {$this->expires}\n";
+		$httpClient = $this->getHttpClient(
+			new SecurityTxtFetcherResponse(200, ['content-type' => 'text/plain; charset=utf-8'], $contents, false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(302, ['location' => 'https://nah.example/'], 'yes but', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(404, [], 'yeah nah', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+		);
+		$checkHostCli = $this->getCheckHostCli($httpClient);
+
+		ob_start();
+		$checkHostCli->check(new Url('https://non-verbose.example'), null, true, false, true, true, true, false, 'Help I need some<body>');
+		$output = ob_get_clean();
+		$expected = <<< EOT
+		[1;90m[Info][0m Parsing security.txt for [1mnon-verbose.example[0m
+		[1;90m[Info][0m Using [1mhttps://non-verbose.example/.well-known/security.txt[0m
 		[1;31m[Error][0m on line [1m2[0m: The file is considered stale and should not be used (How to fix: The Expires field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339, e.g. {$this->getExpiresExample()})
 		[1m[Warning][0m security.txt not found at the top-level path (How to fix: Redirect the top-level file to the one under the /.well-known/ path)
 		[1;31m[Error][0m [1;31mThe file has expired 42 days ago[0m ({$this->expires})
@@ -86,7 +112,7 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(new Url('https://example.com'), 10, true, true, false, true, false, 'Help I need some<body>');
+		$checkHostCli->check(new Url('https://example.com'), 10, true, true, true, false, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		$expected = <<< EOT
 		[1;90m[Info][0m Parsing security.txt for [1mexample.com[0m
@@ -130,7 +156,7 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(new Url('https://example.com'), null, true, true, false, true, false, 'Help I need some<body>');
+		$checkHostCli->check(new Url('https://example.com'), null, true, true, true, false, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		$expected = <<< EOT
 		[1;90m[Info][0m Parsing security.txt for [1mexample.com[0m
@@ -156,7 +182,7 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(new Url('https://example.com'), null, true, true, false, true, false, 'Help I need some<body>');
+		$checkHostCli->check(new Url('https://example.com'), null, true, true, true, false, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		$expected = <<< EOT
 		[1;90m[Info][0m Parsing security.txt for [1mexample.com[0m
@@ -180,8 +206,8 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(new Url('https://example.com'), null, true, true, false, true, true, 'Help I need some1');
-		$checkHostCli->check(new Url('https://example.com'), null, true, true, false, true, false, 'Help I need some<body>');
+		$checkHostCli->check(new Url('https://example.com'), null, true, false, true, false, true, true, 'Help I need some1');
+		$checkHostCli->check(new Url('https://example.com'), null, true, true, true, false, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		$expected = <<< EOT
 		[1;90m[Info][0m Help I need some1
@@ -203,7 +229,7 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(null, null, false, true, false, true, false, 'Help I need some<body>');
+		$checkHostCli->check(null, null, false, false, true, false, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		Assert::same("[Info] Help I need some<body>\n", $output);
 		Assert::same(CheckExitStatus::NoFile->value, $this->exitStatus);
@@ -216,7 +242,7 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
-		$checkHostCli->check(new Url('https://example.com'), null, false, true, false, true, true, 'Help I need some<body>');
+		$checkHostCli->check(new Url('https://example.com'), null, false, false, true, false, true, true, 'Help I need some<body>');
 		$output = ob_get_clean();
 		Assert::same("[Info] Help I need some<body>\n", $output);
 		Assert::same(CheckExitStatus::Ok->value, $this->exitStatus);

--- a/tests/Check/SecurityTxtCheckHostCliTest.phpt
+++ b/tests/Check/SecurityTxtCheckHostCliTest.phpt
@@ -74,25 +74,37 @@ final class SecurityTxtCheckHostCliTest extends TestCase
 	}
 
 
-	public function testCheckErrorWarningNonVerbose(): void
+	public function testCheckErrorWarningVerboseThenNonVerbose(): void
 	{
-		$contents = "Contact: mailto:foo@example.com\nExpires: {$this->expires}\n";
 		$httpClient = $this->getHttpClient(
-			new SecurityTxtFetcherResponse(200, ['content-type' => 'text/plain; charset=utf-8'], $contents, false, '1.1.1.0', SecurityTxtIpAddressType::V4),
-			new SecurityTxtFetcherResponse(302, ['location' => 'https://nah.example/'], 'yes but', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(200, ['content-type' => 'text/plain; charset=utf-8'], "Contact: mailto:foo@example.com\nExpires: {$this->expires}\n", false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(302, ['location' => 'https://nah1.example/'], 'yes but', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(404, [], 'yeah nah', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(200, ['content-type' => 'text/plain; charset=utf-8'], "Contact: mailto:foo@two.example\n", false, '1.1.1.0', SecurityTxtIpAddressType::V4),
+			new SecurityTxtFetcherResponse(302, ['location' => 'https://nah2.example/'], 'yes but', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
 			new SecurityTxtFetcherResponse(404, [], 'yeah nah', false, '1.1.1.0', SecurityTxtIpAddressType::V4),
 		);
 		$checkHostCli = $this->getCheckHostCli($httpClient);
 
 		ob_start();
+		$checkHostCli->check(new Url('https://verbose.example'), null, true, true, true, true, true, false, 'Help I need some<body>');
 		$checkHostCli->check(new Url('https://non-verbose.example'), null, true, false, true, true, true, false, 'Help I need some<body>');
 		$output = ob_get_clean();
 		$expected = <<< EOT
-		[1;90m[Info][0m Parsing security.txt for [1mnon-verbose.example[0m
-		[1;90m[Info][0m Using [1mhttps://non-verbose.example/.well-known/security.txt[0m
+		[1;90m[Info][0m Parsing security.txt for [1mverbose.example[0m
+		[1;90m[Info][0m Loading security.txt from [1mhttps://verbose.example/.well-known/security.txt[0m
+		[1;90m[Info][0m Loading security.txt from [1mhttps://verbose.example/security.txt[0m
+		[1;90m[Info][0m Redirected from [1mhttps://verbose.example/security.txt[0m to [1mhttps://nah1.example/[0m
+		[1;90m[Info][0m Not found [1mhttps://nah1.example/[0m
+		[1;90m[Info][0m Using [1mhttps://verbose.example/.well-known/security.txt[0m
 		[1;31m[Error][0m on line [1m2[0m: The file is considered stale and should not be used (How to fix: The Expires field should contain a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339, e.g. {$this->getExpiresExample()})
 		[1m[Warning][0m security.txt not found at the top-level path (How to fix: Redirect the top-level file to the one under the /.well-known/ path)
 		[1;31m[Error][0m [1;31mThe file has expired 42 days ago[0m ({$this->expires})
+		[1;31m[Error][0m [1;31mThe file is invalid[0m
+		[1;90m[Info][0m Parsing security.txt for [1mnon-verbose.example[0m
+		[1;90m[Info][0m Using [1mhttps://non-verbose.example/.well-known/security.txt[0m
+		[1;31m[Error][0m The Expires field must always be present (How to fix: Add an Expires field with a date and time in the future formatted according to the Internet profile of ISO 8601 as defined in RFC 3339, e.g. 2027-04-14T23:59:59+00:00)
+		[1m[Warning][0m security.txt not found at the top-level path (How to fix: Redirect the top-level file to the one under the /.well-known/ path)
 		[1;31m[Error][0m [1;31mThe file is invalid[0m
 		EOT;
 		Assert::same($expected . "\n", $output);


### PR DESCRIPTION
If specified, the following messages will be printed:
- "Loading security.txt from ..."
- "Redirected from ... to ..."
- "Not found ..."

They were always printed until now.